### PR TITLE
Agent & JRE versions from file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ script:
 
 deploy:
   provider: script
-  script: "(cd build; make) && docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-    && (cd ci; make release)"
+  script: '[ -z "$TRAVIS_TAG" ] && (cd build; make VERSION="$TRAVIS_TAG" )
+    && docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD && (cd ci; make release)'
   on:
     tags: true
     branch: master

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ on-host agent, service integrations and discovery tooling.
 1. Get your desired containerised Infrastructure agent from the tags avaiable at
 [`newrelic/infrastructure`](https://hub.docker.com/r/newrelic/infrastructure/tags)
 
-1. NR will keep latest stable integrations versions at `build/nri-integrations`.
+1. NR will keep latest stable agent and integrations versions at `build/versions`.
    > You could potentially edit the file and set your desired ones at your own risk.
 
 1. Run the following command:
 
    ```bash
-   make VERSION=<bundle version> AGENT_VER=<version of agent> 
+   make VERSION="<bundle version>"
    ```

--- a/build/Makefile
+++ b/build/Makefile
@@ -2,9 +2,7 @@
 
 # meant to be replaced by CI
 VERSION           ?= dev
-AGENT_VER         ?= latest
 # usually fixed
-JRE_VER           ?= 8.242.08-r0
 TAG               ?= newrelic/infrastructure-bundle:${VERSION}
 WORKSPACE_DIR     ?= ./workspace
 VERSIONS_FILE_    := versions
@@ -20,10 +18,9 @@ clean :
 build : workspace
 build : prepare-integrations
 build : prepare-labels
-build : export AGENT_VERSION = ${AGENT_VER}
-build : export JRE_VERSION   = ${JRE_VER}
 build : export IMAGE_TAG     = ${TAG}
 build : export WORKSPACE     = ${WORKSPACE_DIR}
+build : export VERSIONS_FILE = ${VERSIONS_FILE_}
 build :
 	@(./build.sh)
 

--- a/build/assets/README.md
+++ b/build/assets/README.md
@@ -7,9 +7,3 @@ This Docker image contains the [New Relic Infrastructure **Bundle**](https://new
 ### Pulling
 
 `docker pull newrelic/infrastructure-bundle:latest`
-
-
-### Setup
-
-TODO
-

--- a/build/build.sh
+++ b/build/build.sh
@@ -9,12 +9,14 @@ set -e
 #      - WORKSPACE: Local workspace folder for the builder to fetch data from.
 
 # Ensure AGENT_VERSION is set & non-empty
+AGENT_VERSION=$(awk -F, '{if ($1 ~ /^newrelic-infra$/) {print $2}}' ${VERSIONS_FILE})
 if [ -z "$AGENT_VERSION" ]; then
 	echo "AGENT_VERSION is not set or empty"
 	exit 1
 fi
 
 # Ensure JRE_VERSION is set & non-empty
+JRE_VERSION=$(awk -F, '{if ($1 ~ /^jre$/) {print $2}}' ${VERSIONS_FILE})
 if [ -z "$JRE_VERSION" ]; then
 	echo "JRE_VERSION is not set or empty"
 	exit 1

--- a/build/versions
+++ b/build/versions
@@ -1,5 +1,6 @@
 #name,version,arch(optional, amd64 is the default)
 newrelic-infra,1.9.7
+jre,8.242.08-r0
 nri-apache,1.5.0
 nri-cassandra,2.4.0
 nri-consul,2.1.0


### PR DESCRIPTION
- move agent & JRE versions into `build/versions` file
- use master tag to provide bundle version on deploy 