### PR TITLE
Update on-host integrations to latest versions.

### DIFF
--- a/build/versions
+++ b/build/versions
@@ -9,7 +9,7 @@ nri-elasticsearch,4.2.0
 nri-f5,2.1.0
 nri-haproxy,2.1.0
 nri-jmx,2.4.3
-nri-kafka,2.11.2
+nri-kafka,2.12.0
 nri-memcached,2.1.0
 nri-mongodb,2.5.0
 nri-mysql,1.4.0

--- a/build/versions
+++ b/build/versions
@@ -14,7 +14,7 @@ nri-memcached,2.1.0
 nri-mongodb,2.5.0
 nri-mysql,1.4.0
 nri-nagios,2.6.0
-nri-nginx,2.0.0
+nri-nginx,2.0.1
 nri-oracledb,2.3.1
 nri-postgresql,2.3.1
 nri-rabbitmq,2.2.1

--- a/build/versions
+++ b/build/versions
@@ -22,4 +22,4 @@ nri-redis,1.4.0
 nri-snmp,1.1.3
 nri-varnish,2.1.0
 nrjmx,1.5.2,noarch
-nri-discovery-kubernetes,1.0.0,Linux_x86_64
+nri-discovery-kubernetes,1.1.0,Linux_x86_64

--- a/build/versions
+++ b/build/versions
@@ -16,7 +16,7 @@ nri-mysql,1.4.0
 nri-nagios,2.6.0
 nri-nginx,2.0.1
 nri-oracledb,2.3.1
-nri-postgresql,2.3.1
+nri-postgresql,2.3.2
 nri-rabbitmq,2.2.1
 nri-redis,1.4.0
 nri-snmp,1.1.3

--- a/build/versions
+++ b/build/versions
@@ -17,7 +17,7 @@ nri-nagios,2.6.0
 nri-nginx,2.0.1
 nri-oracledb,2.3.1
 nri-postgresql,2.3.2
-nri-rabbitmq,2.2.1
+nri-rabbitmq,2.2.2
 nri-redis,1.4.0
 nri-snmp,1.1.3
 nri-varnish,2.1.0

--- a/build/versions
+++ b/build/versions
@@ -4,7 +4,7 @@ jre,8.242.08-r0
 nri-apache,1.5.0
 nri-cassandra,2.4.0
 nri-consul,2.1.0
-nri-couchbase,2.3.5
+nri-couchbase,2.3.6
 nri-elasticsearch,4.2.0
 nri-f5,2.1.0
 nri-haproxy,2.1.0


### PR DESCRIPTION
Updated:

- `nri-discovery-kubernetes` to `v1.1.0`
- `nri-couchbase` to `v2.3.6`
- `nri-kafka` to `v2.12.0`
- `nri-nginx` to `v2.0.1`
- `nri-postgresql` to `v2.3.2`
- `nri-postgresql` to `v2.3.2`
- `nri-rabbitmq` to `v2.2.2`