### PR TITLE
chore: update build versions

### DIFF
--- a/build/versions
+++ b/build/versions
@@ -1,5 +1,5 @@
 #name,version,arch(optional, amd64 is the default)
-newrelic-infra,1.12.4
+newrelic-infra,1.13.2
 jre,8.252.09-r0
 nri-apache,1.5.0
 nri-cassandra,2.4.2

--- a/build/versions
+++ b/build/versions
@@ -22,5 +22,5 @@ nri-redis,1.4.0
 nri-snmp,1.2.0
 nri-varnish,2.1.0
 nrjmx,1.5.2,noarch
-nri-discovery-kubernetes,1.2.0,Linux_x86_64
+nri-discovery-kubernetes,1.3.0,Linux_x86_64
 nri-ecs,1.1.0

--- a/build/versions
+++ b/build/versions
@@ -21,6 +21,6 @@ nri-rabbitmq,2.2.3
 nri-redis,1.4.0
 nri-snmp,1.2.0
 nri-varnish,2.1.0
-nrjmx,1.5.2,noarch
+nrjmx,1.6.1,noarch
 nri-discovery-kubernetes,1.3.0,Linux_x86_64
 nri-ecs,1.1.0

--- a/build/versions
+++ b/build/versions
@@ -2,7 +2,7 @@
 newrelic-infra,1.13.2
 jre,8.252.09-r0
 nri-apache,1.5.0
-nri-cassandra,2.4.2
+nri-cassandra,2.6.0
 nri-consul,2.1.1
 nri-couchbase,2.3.7
 nri-elasticsearch,4.2.0

--- a/build/versions
+++ b/build/versions
@@ -21,6 +21,6 @@ nri-rabbitmq,2.2.3
 nri-redis,1.4.0
 nri-snmp,1.2.0
 nri-varnish,2.1.0
-nrjmx,1.6.1,noarch
+nrjmx,1.5.2,noarch
 nri-discovery-kubernetes,1.3.0,Linux_x86_64
 nri-ecs,1.1.0


### PR DESCRIPTION
Update infrastructure agent [v1.13.2](https://github.com/newrelic/infrastructure-agent/releases/tag/1.13.2)
Update nri-cassandra [v2.6.0](https://github.com/newrelic/nri-cassandra/releases/tag/v2.6.0)
Update nri-discovery-kubernetes [v1.3.0](https://github.com/newrelic/nri-discovery-kubernetes/releases/tag/v1.3.0)