### PR TITLE
downgrading jre and nrjmx versions <DO NOT MERGE>

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,7 +19,7 @@ FROM $base_image AS bundle
 ARG jre_version
 
 # required for nri-jmx
-RUN apk add --no-cache openjdk11-jre-headless=${jre_version}
+RUN apk add --no-cache openjdk8-jre=${jre_version}
 
 # integrations
 COPY --from=builder /var/db/newrelic-infra /var/db/newrelic-infra

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,10 +23,8 @@ RUN apk add --no-cache openjdk8-jre=${jre_version}
 
 # integrations
 COPY --from=builder /var/db/newrelic-infra /var/db/newrelic-infra
-COPY --from=builder /usr/lib/nrjmx /usr/lib/nrjmx
-COPY --from=builder /usr/share/doc/nrjmx /usr/share/doc/nrjmx
-COPY --from=builder /usr/bin/nrjmx /usr/bin/nrjmx
-COPY --from=builder /usr/bin/jmxterm /usr/bin/jmxterm
+COPY --from=builder /usr/bin/nrjmx* /usr/bin/
+COPY --from=builder /usr/bin/jmxterm.jar /usr/bin/
 
 ENV NRIA_PASSTHROUGH_ENVIRONMENT=ECS_CONTAINER_METADATA_URI,FARGATE
 

--- a/build/versions
+++ b/build/versions
@@ -1,6 +1,6 @@
 #name,version,arch(optional, amd64 is the default)
 newrelic-infra,1.14.2
-jre,11.0.9_p11-r0
+jre,8.252.09-r0
 nri-apache,1.5.0
 nri-cassandra,2.6.0
 nri-consul,2.1.2
@@ -21,6 +21,6 @@ nri-rabbitmq,2.2.3
 nri-redis,1.6.0
 nri-snmp,1.2.0
 nri-varnish,2.1.0
-nrjmx,1.6.2,noarch
+nrjmx,1.5.2,noarch
 nri-discovery-kubernetes,1.3.0,Linux_x86_64
 nri-ecs,1.1.0


### PR DESCRIPTION
this PR addresses a `java.sql.time` error found when upgrading a customer from JRE 8 >> JRE 11