### PR TITLE
Remove nri-oracledb

### DIFF
--- a/bundle.yml
+++ b/bundle.yml
@@ -45,9 +45,6 @@ integrations:
     version: 2.7.1
   - name: nri-nginx
     version: 3.1.0
-  - name: nri-oracledb
-    version: 2.5.1
-    archs: [ amd64 ]
   - name: nri-postgresql
     version: 2.7.0
   - name: nri-rabbitmq


### PR DESCRIPTION
`nri-oracledb` uses [godror](https://github.com/godror/godror), which itself needs the [oracle client library](https://oracle.github.io/odpi/doc/installation.html) installed on the running host in order to work properly.

Since this library is not included in the infrastructure-bundle, it doesn't make sense to include `nri-oracledb` in it.