### PR TITLE
ci: use updated snyk action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ jobs:
   build:
     name: Build and scan image
     runs-on: ubuntu-latest
+    env:  # Variables as understood by docker-build.sh
+      DOCKER_IMAGE: newrelic/infrastructure-bundle
+      DOCKER_IMAGE_TAG: ci
     steps:
       - uses: actions/checkout@v2
       - name: Set up QEMU
@@ -33,16 +36,11 @@ jobs:
           # Build and load for amd64 only (for snyk)
           DOCKER_PLATFORMS=linux/amd64 ./docker-build.sh . --load
 
-      - name: Run Snyk via Docker
-        run: docker run -t -e "SNYK_TOKEN=${SNYK_TOKEN}" -v ${PWD}/workspace:/project -v "/var/run/docker.sock:/var/run/docker.sock" snyk/snyk-cli:docker test --docker "newrelic/infrastructure-bundle:dev" --severity-threshold=high --org=ohai  --project-name="newrelic/infrastructure-bundle"
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      # Fails without an error so looking into this to replace above step
       - name: Run Snyk to check Docker image for vulnerabilities
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image: newrelic/infrastructure-bundle:dev
-          args: --severity-threshold=high --file=build/workspace/Dockerfile --org=ohai --project-name='newrelic/infrastructure-bundle'
+          image: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_TAG }}
+          args: --file=Dockerfile


### PR DESCRIPTION
Previous CI pipeline ran two different snyk checks, one being unreadable and the other having wrong arguments.

This PR moves to the Snyk action, with correct arguments.