### PR TITLE
update version of integration services

### DIFF
--- a/bundle.yml
+++ b/bundle.yml
@@ -56,6 +56,7 @@ integrations:
     version: 1.6.2
   - name: nri-snmp
     version: 1.3.0
+    archs: [ amd64 ]
   - name: nri-varnish
     version: 2.2.0
   - name: nrjmx

--- a/bundle.yml
+++ b/bundle.yml
@@ -16,45 +16,45 @@ integrations:
 #    archReplacements: # replace keys with values for {{.Arch}}. Useful for sketchy naming schemes.
 #      amd64: x86_64
   - name: nri-apache
-    version: 1.5.0
+    version: 1.6.0
   - name: nri-cassandra
-    version: 2.6.0
+    version: 2.8.0
   - name: nri-consul
-    version: 2.1.2
+    version: 2.3.0
   - name: nri-couchbase
-    version: 2.3.7
+    version: 2.4.0
   - name: nri-elasticsearch
-    version: 4.3.3
+    version: 4.3.5
   - name: nri-f5
-    version: 2.2.0
+    version: 2.3.0
   - name: nri-haproxy
-    version: 2.1.1
+    version: 2.2.1
   - name: nri-jmx
-    version: 2.4.5
+    version: 2.4.6
   - name: nri-kafka
-    version: 2.13.8
+    version: 2.15.0
   - name: nri-memcached
-    version: 2.1.2
+    version: 2.2.0
   - name: nri-mongodb
-    version: 2.5.0
-  - name: nri-mysql
-    version: 1.4.0
-  - name: nri-nagios
     version: 2.6.0
+  - name: nri-mysql
+    version: 1.6.0
+  - name: nri-nagios
+    version: 2.7.1
   - name: nri-nginx
-    version: 3.0.1
+    version: 3.1.0
   - name: nri-oracledb
     version: 2.5.1
   - name: nri-postgresql
-    version: 2.6.1
+    version: 2.7.0
   - name: nri-rabbitmq
-    version: 2.2.3
+    version: 2.3.0
   - name: nri-redis
-    version: 1.6.0
+    version: 1.6.2
   - name: nri-snmp
-    version: 1.2.0
+    version: 1.3.0
   - name: nri-varnish
-    version: 2.1.0
+    version: 2.2.0
   - name: nrjmx
     version: 1.5.2
     url: https://download.newrelic.com/infrastructure_agent/binaries/linux/noarch/nrjmx_linux_{{.Version}}_noarch.tar.gz

--- a/bundle.yml
+++ b/bundle.yml
@@ -33,7 +33,6 @@ integrations:
     version: 2.2.1
   - name: nri-jmx
     version: 2.4.6
-    archs: [ amd64 ]
   - name: nri-kafka
     version: 2.15.0
   - name: nri-memcached
@@ -57,7 +56,6 @@ integrations:
     version: 1.6.2
   - name: nri-snmp
     version: 1.3.0
-    archs: [ amd64 ]
   - name: nri-varnish
     version: 2.2.0
   - name: nrjmx


### PR DESCRIPTION
Updated Integration services  in this PR make use of the v3.6.7 Infrastructure SDK