### PR TITLE
Bump agent version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 out/
 .idea
+/vendor
+/build

--- a/bundle.yml
+++ b/bundle.yml
@@ -1,6 +1,6 @@
 # Version of the base agent image to use (`newrelic/infrastructure).
-# This is used by the `docker-build.sh` wrapper if AGENT_VERSION is not set.
-agentVersion: 1.18.1
+# This is used by the `docker-build.sh` wrapper if AGENT_VERSION is not set
+agentVersion: 1.19.2
 
 # Used as defaults for all integrations below, can be overridden. Template.
 url: https://download.newrelic.com/infrastructure_agent/binaries/linux/{{.Arch}}/{{.Name}}_linux_{{.Version}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
- chore: bump agent version 1.19.2
- feat: gitignore vendor and build
