### PR TITLE
bundle.yml: use github as stagingUrl

### DIFF
--- a/bundle.yml
+++ b/bundle.yml
@@ -5,11 +5,11 @@ agentVersion: 1.20.2
 # Used as defaults for all integrations below, can be overridden. Template.
 url: https://download.newrelic.com/infrastructure_agent/binaries/linux/{{.Arch}}/{{.Name}}_linux_{{.Version}}_{{.Arch}}.tar.gz
 # stagingUrl will be used if the download is invoked with -staging. Template.
-stagingUrl: https://nr-downloads-ohai-staging.s3.amazonaws.com/infrastructure_agent/binaries/linux/{{.Arch}}/{{.Name}}_linux_{{.Version}}_{{.Arch}}.tar.gz
+stagingUrl: https://github.com/newrelic/{{.Name}}/releases/download/v{{.Version}}/{{.Name}}_linux_{{.Version}}_{{.Arch}}.tar.gz
 
 # List of architectures to fetch.
 archs: [ amd64, arm, arm64 ]
-# Github repo hosting the integration. Used to fetch the latest available version when using -latest. Template.
+# GitHub repo hosting the integration. Used to fetch the latest available version when using -latest. Template.
 repo: newrelic/{{.Name}}
 
 # List of integrations to download.


### PR DESCRIPTION
Staging s3 bucket/repo is not considered stable, since we often overwrite it with a copy of the production repo. This can cause the downloader to fail, because a prerelease that exists in GitHub is not found in the s3 repo.

With this change, prereleases will be downloaded directly from GitHub releases.