### PR TITLE
downloader: make integration versions start with v

### DIFF
--- a/bundle.yml
+++ b/bundle.yml
@@ -2,10 +2,13 @@
 # This is used by the `docker-build.sh` wrapper if AGENT_VERSION is not set
 agentVersion: 1.20.2
 
+# url, stagingUrl, and repo fields are compiled as templates. The `trimv` helper function can be used to remove the leading v
+# from a version string.
+
 # Used as defaults for all integrations below, can be overridden. Template.
-url: https://download.newrelic.com/infrastructure_agent/binaries/linux/{{.Arch}}/{{.Name}}_linux_{{.Version}}_{{.Arch}}.tar.gz
+url: https://download.newrelic.com/infrastructure_agent/binaries/linux/{{.Arch}}/{{.Name}}_linux_{{.Version | trimv}}_{{.Arch}}.tar.gz
 # stagingUrl will be used if the download is invoked with -staging. Template.
-stagingUrl: https://github.com/newrelic/{{.Name}}/releases/download/v{{.Version}}/{{.Name}}_linux_{{.Version}}_{{.Arch}}.tar.gz
+stagingUrl: https://github.com/newrelic/{{.Name}}/releases/download/{{.Version}}/{{.Name}}_linux_{{.Version | trimv}}_{{.Arch}}.tar.gz
 
 # List of architectures to fetch.
 archs: [ amd64, arm, arm64 ]
@@ -28,54 +31,54 @@ integrations:
 #    stagingUrl: "" # Defaults to global `stagingUrl`.
 #    repo: "" # Defaults to global `repo`.
   - name: nri-apache
-    version: 1.6.1
+    version: v1.6.1
   - name: nri-cassandra
-    version: 2.8.1
+    version: v2.8.1
   - name: nri-consul
-    version: 2.3.1
+    version: v2.3.1
   - name: nri-couchbase
-    version: 2.4.1
+    version: v2.4.1
   - name: nri-ecs
-    version: 1.3.1
+    version: v1.3.1
   - name: nri-elasticsearch
-    version: 4.3.6
+    version: v4.3.6
   - name: nri-f5
-    version: 2.3.1
+    version: v2.3.1
   - name: nri-haproxy
-    version: 2.2.2
+    version: v2.2.2
   - name: nri-jmx
-    version: 2.4.8
+    version: v2.4.8
   - name: nri-kafka
-    version: 2.16.2
+    version: v2.16.2
   - name: nri-memcached
-    version: 2.2.1
+    version: v2.2.1
   - name: nri-mongodb
-    version: 2.6.1
+    version: v2.6.1
   - name: nri-mysql
-    version: 1.6.1
+    version: v1.6.1
   - name: nri-nagios
-    version: 2.7.2
+    version: v2.7.2
   - name: nri-nginx
-    version: 3.1.2
+    version: v3.1.2
   - name: nri-postgresql
-    version: 2.7.2
+    version: v2.7.2
   - name: nri-rabbitmq
-    version: 2.3.1
+    version: v2.3.1
   - name: nri-redis
-    version: 1.6.3
+    version: v1.6.3
   - name: nri-snmp
-    version: 1.4.0
+    version: v1.4.0
     archs: [ amd64 ]
   - name: nri-varnish
-    version: 2.2.1
+    version: v2.2.1
   - name: nrjmx
-    version: 1.5.3
-    url: https://download.newrelic.com/infrastructure_agent/binaries/linux/noarch/nrjmx_linux_{{.Version}}_noarch.tar.gz
-    stagingUrl: https://nr-downloads-ohai-staging.s3.amazonaws.com/infrastructure_agent/binaries/linux/noarch/nrjmx_linux_{{.Version}}_noarch.tar.gz
+    version: v1.5.3
+    url: https://download.newrelic.com/infrastructure_agent/binaries/linux/noarch/nrjmx_linux_{{.Version | trimv}}_noarch.tar.gz
+    stagingUrl: https://github.com/newrelic/{{.Name}}/releases/download/{{.Version}}/nrjmx_linux_{{.Version | trimv}}_noarch.tar.gz
   - name: nri-discovery-kubernetes
-    version: 1.4.0
-    url: https://github.com/newrelic/{{.Name}}/releases/download/v{{.Version}}/{{.Name}}_{{.Version}}_Linux_{{.Arch}}.tar.gz
-    stagingUrl: https://github.com/newrelic/{{.Name}}/releases/download/v{{.Version}}/{{.Name}}_{{.Version}}_Linux_{{.Arch}}.tar.gz
+    version: v1.4.0
+    url: https://github.com/newrelic/{{.Name}}/releases/download/{{.Version}}/{{.Name}}_{{.Version | trimv}}_Linux_{{.Arch}}.tar.gz
+    stagingUrl: https://github.com/newrelic/{{.Name}}/releases/download/{{.Version}}/{{.Name}}_{{.Version | trimv}}_Linux_{{.Arch}}.tar.gz
     subpath: var/db/newrelic-infra
     archReplacements:
       amd64: x86_64

--- a/downloader.go
+++ b/downloader.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"sync"
 	"text/template"
-	"time"
 
 	"github.com/google/go-github/v38/github"
 	"golang.org/x/oauth2"
@@ -328,14 +327,6 @@ func (i *integration) overrideVersion(gh *github.Client, includePrereleases bool
 		// Filter out pre-releases if `includePrereleases` is not set.
 		if !includePrereleases && r.GetPrerelease() {
 			log.Printf("skipping pre-release %s %s", i.Name, r.GetTagName())
-			continue
-		}
-
-		// Filter releases published less than one hour ago, since it is likely that their pipeline is still running
-		// and packages are not in the staging repo yet.
-		age := time.Since(r.GetPublishedAt().Time)
-		if age < 1*time.Hour {
-			log.Printf("skipping %s %s as it's too young (%v)", i.Name, r.GetTagName(), age)
 			continue
 		}
 


### PR DESCRIPTION
This makes the contents of bundle.yml consistent with the tags and release names used in GitHub, allowing for easier comparison and replacement.
A template helper function, trimv, has been added to remove the leading v from name templates.