### PR TITLE
fix repolinter issue within README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Community Plus header](https://raw.githubusercontent.com/newrelic/opensource-website/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)``
+[![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
 
 # New Relic infrastructure monitoring bundle
 


### PR DESCRIPTION
`repolinter` still complaining about the header.