### PR TITLE
chore: remove nri-ecs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,3 @@ RUN if [ -n "${jre_version}" ]; then apk add --no-cache openjdk8-jre=${jre_versi
 
 # integrations
 COPY out/${TARGETARCH} /
-
-ENV NRIA_PASSTHROUGH_ENVIRONMENT=ECS_CONTAINER_METADATA_URI,FARGATE

--- a/bundle.yml
+++ b/bundle.yml
@@ -43,10 +43,6 @@ integrations:
     version: v2.4.1
   - name: nri-couchbase
     version: v2.5.1
-  - name: nri-ecs
-    version: v1.3.1
-    # This integration no longer produce packages on new releases. This is a workaround to prevent nightly to fail.
-    stagingUrl: https://github.com/newrelic/nri-ecs/releases/download/v1.3.1/nri-ecs_linux_1.3.1_{{.Arch}}.tar.gz
   - name: nri-elasticsearch
     version: v4.5.1
   - name: nri-f5


### PR DESCRIPTION
Since `nri-ecs` integration will be having it's own image based on the bundle, this PR removes the integration.

Also removes the ECS related configuration (metadata uri and Fargate) passthrough environment since this is already added during [installation](https://github.com/newrelic/nri-ecs/blob/main/deploy/fargate_sidecar_example.json#L39) of the ECS integration.

## Important Note
Installations of ECS cluster that points to the `latest` image of the bundle will break after this PR is relased.
This release needs to be done after the `nri-ecs` image is released and existing customers pointing to `latest` bundle running ecs integration are notified.

# For Release Notes 
## BREAKING
- Removes the `nri-ecs` integration. This integration has its own image `newrelic/nri-ecs` from `v1.4.0` which is based on the `infrastructure-bundle` image, but there are no braking changes on the integration and the resto of the on-host integration are still in the image. If your ECS Task Definition points to `newrelic/infrastructure-bundle:latest` you need to change it to `newrelic/nri-ecs:latest`.