### PR TITLE
fix: use fixed staging url for nri-ecs

### DIFF
--- a/bundle.yml
+++ b/bundle.yml
@@ -45,6 +45,8 @@ integrations:
     version: v2.5.1
   - name: nri-ecs
     version: v1.3.1
+    # This integration no longer produce packages on new releases. This is a workaround to prevent nightly to fail.
+    stagingUrl: https://github.com/newrelic/nri-ecs/releases/download/v1.3.1/nri-ecs_linux_1.3.1_arm.tar.gz
   - name: nri-elasticsearch
     version: v4.5.1
   - name: nri-f5

--- a/bundle.yml
+++ b/bundle.yml
@@ -46,7 +46,7 @@ integrations:
   - name: nri-ecs
     version: v1.3.1
     # This integration no longer produce packages on new releases. This is a workaround to prevent nightly to fail.
-    stagingUrl: https://github.com/newrelic/nri-ecs/releases/download/v1.3.1/nri-ecs_linux_1.3.1_arm.tar.gz
+    stagingUrl: https://github.com/newrelic/nri-ecs/releases/download/v1.3.1/nri-ecs_linux_1.3.1_{{.Arch}}.tar.gz
   - name: nri-elasticsearch
     version: v4.5.1
   - name: nri-f5


### PR DESCRIPTION
Since nri-ecs integration does not generate more packages on releases (now it has it's own image) the nightly workflows [fails](https://github.com/newrelic/infrastructure-bundle/runs/4160576873?check_suite_focus=true#step:7:61) when a new release of this integration is created. 

This will be a temporal workaround until nri-ecs is removed from the bundle #130 , which it needs to wait until Product confirmation. 