### PR TITLE
Add build arg for disabling default integrations (nri-docker)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,17 @@ FROM $base_image
 ARG TARGETOS
 ARG TARGETARCH
 ARG jre_version
+ARG disable_default_integrations
+
+RUN if [ "$disable_default_integrations" = "true" ]; then rm -rf /etc/newrelic-infra/integrations.d/*; fi
 
 # required for nri-jmx
 RUN if [ -n "${jre_version}" ]; then apk add --no-cache openjdk8-jre=${jre_version}; else apk add --no-cache openjdk8-jre; fi
 
 # integrations
 COPY out/${TARGETARCH} /
+
+# creating the nri-agent user used only in K8s unprivileged mode
+RUN addgroup -g 2000 nri-agent && adduser -D -u 1000 -G nri-agent nri-agent
 
 ENV NRIA_PASSTHROUGH_ENVIRONMENT=ECS_CONTAINER_METADATA_URI,FARGATE

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -6,6 +6,7 @@ DOCKER_PLATFORMS=${DOCKER_PLATFORMS:-linux/amd64,linux/arm64,linux/arm}
 JRE_VERSION=${JRE_VERSION:-} # Blank will pull default version for alpine image
 DOCKER_IMAGE=${DOCKER_IMAGE:-newrelic/infrastructure-bundle}
 DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-dev} # Overwritten by CI from the release tag
+DISABLE_DEFAULT_INTEGRATIONS=${DISABLE_DEFAULT_INTEGRATIONS:-} # If true disable default integrations
 
 # Get default AGENT_VERSION from downloader.go
 if [ -z "$AGENT_VERSION" ]; then
@@ -20,5 +21,6 @@ docker buildx build \
   --platform="${DOCKER_PLATFORMS}" \
   --build-arg agent_version="$AGENT_VERSION" \
   --build-arg jre_version="$JRE_VERSION" \
+  --build-arg disable_default_integrations="$DISABLE_DEFAULT_INTEGRATIONS" \
   -t "${DOCKER_IMAGE}:${DOCKER_IMAGE_TAG}" \
   "$@"


### PR DESCRIPTION
- This is not definitive and would need also a new image release with the  tag : infrastructure-bundle-k8s