### PR TITLE
Add agent user having minimum privileges to the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ ARG jre_version
 # required for nri-jmx
 RUN if [ -n "${jre_version}" ]; then apk add --no-cache openjdk8-jre=${jre_version}; else apk add --no-cache openjdk8-jre; fi
 
+# creating the nri-agent user used only in K8s unprivileged mode
+RUN addgroup -g 2000 nri-agent && adduser -D -u 1000 -G nri-agent nri-agent
+
 # integrations
 COPY out/${TARGETARCH} /
 


### PR DESCRIPTION
- We add the user that is used only in K8s unprivileged mode. This user has no privileges so it's secure to add it in any environment.