### PR TITLE
delete nri-varnish integration

### DIFF
--- a/bundle.yml
+++ b/bundle.yml
@@ -71,8 +71,6 @@ integrations:
     version: v1.9.0
   - name: nri-snmp
     version: v1.5.0
-  - name: nri-varnish
-    version: v2.5.1
   - name: nrjmx
     version: v2.0.1
     url: https://download.newrelic.com/infrastructure_agent/binaries/linux/noarch/nrjmx_linux_{{.Version | trimv}}_noarch.tar.gz


### PR DESCRIPTION
`nri-varnish` cannot run inside the container since it uses the `varnishstats` cli tool. The integration doesn't have any documentation to run in containerized environment for this reason.