### PR TITLE
ci/security: make trivy fail on CRITICALs only

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -47,4 +47,4 @@ jobs:
           SNYK_TOKEN: ${{ secrets.CAOS_SNYK_TOKEN }}
         with:
           image: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_TAG }}
-          args: --file=Dockerfile
+          args: --file=Dockerfile --severity-threshold=critical

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,7 +39,7 @@ jobs:
           format: table
           exit-code: 1
           ignore-unfixed: true
-          severity: CRITICAL,HIGH
+          severity: CRITICAL
 
       - name: Run Snyk to check Docker image for vulnerabilities
         uses: snyk/actions/docker@master


### PR DESCRIPTION
This PR will cause trivy to neither report nor fail vulns that are not flagged as CRITICAL. This aims to reduce the noise of the security workflow by making it adhere better to our current policies, instead of taking for granted it will always be red and therefore never checking what it is actually saying.