### PR TITLE
Configure automerge for renovatebot (NR-107049)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,11 +39,17 @@
   ],
   "packageRules": [
     {
-      // Group all integration bumps together in a single PR.
-      "matchDatasources": [
-        "github-releases"
-      ],
-      "groupName": "Integrations",
+      "matchUpdateTypes": ["minor", "patch"],
+      // Exclude any dependencies which are pre-1.0.0 because those can make breaking changes at any time
+      // according to the SemVer spec.
+      "matchCurrentVersion": "!/^(0|v0)/",
+      // Renovate will do the following when detecting a new dependency bump:
+      // - If it's one of the exclusions it will create a PR (major, 0. or v0. and sarama)
+      // - In case it matches one of the rest cases, it will create a branch that will be auto merged if tests pass.
+      // - If in the previous step tests fail, a PR will be created instead of merging the branch.
+      "automerge": true,
+      "automergeType": "branch",
+      "pruneBranchAfterAutomerge": true
     },
     {
       // Assign PRs related to the agent to the caos team.
@@ -51,13 +57,6 @@
         "newrelic/infrastructure"
       ],
       "reviewers": ["team:caos"],
-    },
-    {
-      // Group all GHA bumps together in a single PR.
-      "matchManagers": [
-        "github-actions"
-      ],
-      "groupName": "Github Actions"
     },
     {
       // NRJMX 1.6.x is known to be broken, so we skip 1.6.x.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,7 +56,7 @@
       "matchPackageNames": [
         "newrelic/infrastructure"
       ],
-      "reviewers": ["team:caos"],
+      "reviewers": ["team:caos"]
     },
     {
       // NRJMX 1.6.x is known to be broken, so we skip 1.6.x.


### PR DESCRIPTION
It is a copy and paste from the already working `nri-kafka` configuration removing the `sarama` dependency.: https://github.com/newrelic/nri-kafka/blob/master/renovate.json5#L12-L23

I also removed rules to group dependencies as they do not make sense anymore as we would want to fail individually.