### PR TITLE
feat(latestAgent): use latest agent in nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,5 +44,7 @@ jobs:
           username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
           password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
       - name: Build and push docker image
-        run: ./docker-build.sh . --push
+        run: |
+          export AGENT_VERSION=`go run ./downloader.go -agent-version-latest -staging`
+          ./docker-build.sh . --push
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -16,6 +16,8 @@ if [ -z "$AGENT_VERSION" ]; then
     fi
 fi
 
+echo Building the image leveraging agent_version=$AGENT_VERSION
+
 docker buildx build \
   --platform="${DOCKER_PLATFORMS}" \
   --build-arg agent_version="$AGENT_VERSION" \


### PR DESCRIPTION
This change allows us to have the nightly build with the latest agent version as base.

This is useful for our canaries
Example:
```
export AGENT_VERSION=`go run ./downloader.go -agent-version-latest `        
./docker-build.sh . --push

2024/02/19 18:03:38 infrastructure-agent 1.48.4 -> 1.49.0
Building the image leveraging agent_version=1.49.0
[...]
```

```
export AGENT_VERSION=`go run ./downloader.go -agent-version-latest -staging`
./docker-build.sh . --push

2024/02/19 18:03:29 Fetching releases for infrastructure-agent...
2024/02/19 18:03:34 infrastructure-agent 1.48.4 -> 1.49.1
Building the image leveraging agent_version=1.49.1-rc
[...]
```