### PR TITLE
ci: fail on nightly build on detected vulnerabilities

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,6 @@ jobs:
         run: go run downloader.go -staging -override-latest
 
       - name: Run Trivy vulnerability scanner
-        continue-on-error: true
         uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_TAG }}


### PR DESCRIPTION
Nightly build's security scanning was set up to continue on errors and we don't want that (that's why we set up notifications [here](https://github.com/newrelic/infrastructure-bundle/pull/436)). This disables that.