### PR TITLE
ci: enable trivy action cache

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,7 +37,6 @@ jobs:
           exit-code: 1
           ignore-unfixed: true
           severity: CRITICAL,HIGH
-          cache: false
 
       - uses: docker/login-action@v3
         with:

--- a/.github/workflows/on-demand.yml
+++ b/.github/workflows/on-demand.yml
@@ -37,7 +37,6 @@ jobs:
           exit-code: 1
           ignore-unfixed: true
           severity: CRITICAL,HIGH
-          cache: false
 
       - uses: docker/login-action@v3
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,7 +40,6 @@ jobs:
           exit-code: 1
           ignore-unfixed: true
           severity: "CRITICAL,HIGH"
-          cache: false
 
       - name: Run Trivy in report mode
         # Only generate sarif when running nightly on the main branch.


### PR DESCRIPTION
We were rate-limited pretty quickly with the latest changes that attempt to download the CVE database every time, so let's enable the cache again and see if the updated action version works better with it from now on.