### PR TITLE
security workflow does not repeat nightly scans

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - renovate/**
   pull_request:
-  schedule:
-    - cron: "14 3 * * *" # Daily at 3:14 AM
 
 jobs:
   build:
@@ -43,37 +41,3 @@ jobs:
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
-
-      - name: Run Trivy in report mode
-        # Only generate sarif when running nightly on the main branch.
-        if: ${{ github.event_name == 'schedule' }}
-        uses: aquasecurity/trivy-action@0.28.0
-        with:
-          image-ref: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_TAG }}
-          format: "template"
-          template: "@/contrib/sarif.tpl"
-          output: "trivy-results.sarif"
-          ignore-unfixed: false # Get full report when running nightly.
-          severity: "CRITICAL,HIGH"
-        env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        # Only upload sarif when running nightly on the main branch.
-        if: ${{ github.event_name == 'schedule' }}
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: "trivy-results.sarif"
-
-  notify-failure:
-    if: ${{ github.event_name == 'schedule' && failure() }}
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify failure via Slack
-        uses: archive/github-actions-slack@master
-        with:
-          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
-          slack-channel: ${{ secrets.CAOS_COREINT_SLACK_CHANNEL }}
-          slack-text: "❌ `'newrelic/infrastructure-bundle'`: [security pipeline failed](${{ github.server_url }}/newrelic/infrastructure-bundle/actions/runs/${{ github.run_id }})."


### PR DESCRIPTION
The reusable security workflow (https://github.com/newrelic/coreint-automation/blob/8e5f750ba1e151b93454c56aeb1f6dbcea0e3b00/.github/workflows/reusable_security.yaml) scans the repo ( codebase ) for vulnerabilities with Trivy.
This cannot be used for `infrastructure-bundle` because we need to build a docker Image and then scan that docker image for vulnerabilities by running trivy in table-mode.
We have code that does this in the reusable nightly workflow for docker images. But that workflow also publishes the nightly build so reusing it just to scan the image on pull request does not make sense.

The code that runs the security check on a schedule can be removed because that is being handled by the nightly.

The code that runs the security check on a pull request should be left as is since we do not have a reusable workflow that only builds and scans a docker image.