### PR TITLE
feat(fips): add fips compliant image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,3 +38,36 @@ jobs:
 
       - name: Check if CHANGELOG is valid
         uses: newrelic/release-toolkit/validate-markdown@v1
+  
+  build-fips:
+    name: Build fips and scan image
+    runs-on: ubuntu-latest
+    env:  # Variables as understood by docker-build.sh
+      DOCKER_IMAGE: newrelic/infrastructure-bundle-fips
+      DOCKER_IMAGE_TAG: ci
+      OUTDIR: out-fips
+      BASE_IMAGE_NAME: newrelic/infrastructure-fips
+      DOCKER_PLATFORMS: linux/amd64,linux/arm64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Download integrations
+        run: go run downloader.go -bundle=bundle-fips.yml -outdir=out-fips
+
+      # Due to a limitation of buildx, multiarch images cannot be `--load`ed to the host
+      # Therefore, to test vulnerabilities, we also re-build (fast with cache) for amd64 only and load it
+      - name: Build docker image for all platforms
+        run: |
+          # Test build, but not load, for all archs
+          ./docker-build.sh .
+          # Build and load for amd64 only (for snyk)
+          DOCKER_PLATFORMS=linux/amd64 ./docker-build.sh . --load
+
+      - name: Check if CHANGELOG is valid
+        uses: newrelic/release-toolkit/validate-markdown@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - master
       - main
-  workflow_dispatch:
 
 jobs:
   nightly:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,3 +57,4 @@ jobs:
       setup_go: true
       go_version_file: go.mod
       trivy_scan: true
+      

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,3 +29,28 @@ jobs:
       setup_go: true
       go_version_file: go.mod
       trivy_scan: true
+  
+  nightly-fips:
+    uses: newrelic/coreint-automation/.github/workflows/reusable_nightly.yaml@v3
+    secrets:
+      docker_username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
+      docker_password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
+      slack_channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+      slack_token: ${{ secrets.COREINT_SLACK_TOKEN }}
+    with:
+      docker_image: newrelic/infrastructure-bundle-fips
+      docker_tag: nightly
+      target_branches: "master,main"
+      build_command: |
+        export AGENT_VERSION=`go run ./downloader.go -agent-version-latest -staging`
+        go run downloader.go -staging -override-latest -bundle=bundle-fips.yml -outdir=out-fips
+        export DOCKER_PLATFORMS=linux/amd64,linux/arm64
+        export DOCKER_IMAGE_TAG=nightly
+        export OUTDIR=out-fips
+        export BASE_IMAGE_NAME=newrelic/infrastructure-fips
+        ./docker-build.sh . --push
+      setup_qemu: true
+      setup_buildx: true
+      setup_go: true
+      go_version_file: go.mod
+      trivy_scan: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,9 +6,11 @@ on:
     branches:
       - master
       - main
+  workflow_dispatch:
 
 jobs:
   nightly:
+    name: Nightly standard build
     uses: newrelic/coreint-automation/.github/workflows/reusable_nightly.yaml@v3
     secrets:
       docker_username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
@@ -20,7 +22,7 @@ jobs:
       docker_tag: nightly
       target_branches: "master,main"
       build_command: |
-        export AGENT_VERSION=`go run ./downloader.go -agent-version-latest -staging`
+        export AGENT_VERSION=$(go run ./downloader.go -agent-version-latest -staging)
         go run downloader.go -staging -override-latest
         export DOCKER_IMAGE_TAG=nightly
         ./docker-build.sh . --push
@@ -31,6 +33,7 @@ jobs:
       trivy_scan: true
   
   nightly-fips:
+    name: Nightly FIPS build
     uses: newrelic/coreint-automation/.github/workflows/reusable_nightly.yaml@v3
     secrets:
       docker_username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
@@ -42,7 +45,7 @@ jobs:
       docker_tag: nightly
       target_branches: "master,main"
       build_command: |
-        export AGENT_VERSION=`go run ./downloader.go -agent-version-latest -staging`
+        export AGENT_VERSION=$(go run ./downloader.go -agent-version-latest -staging)
         go run downloader.go -staging -override-latest -bundle=bundle-fips.yml -outdir=out-fips
         export DOCKER_PLATFORMS=linux/amd64,linux/arm64
         export DOCKER_IMAGE_TAG=nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,4 +57,3 @@ jobs:
       setup_go: true
       go_version_file: go.mod
       trivy_scan: true
-      

--- a/.github/workflows/on-demand.yml
+++ b/.github/workflows/on-demand.yml
@@ -47,3 +47,48 @@ jobs:
           password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
       - name: Build and push docker image
         run: ./docker-build.sh . --push
+  
+  build-fips:
+    name: Build fips and push image
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_IMAGE: newrelic/infrastructure-bundle-fips
+      DOCKER_IMAGE_TAG: dev
+      AGENT_VERSION: ${{ github.event.inputs.agent_version }}
+      OUTDIR: out-fips
+      BASE_IMAGE_NAME: newrelic/infrastructure-fips
+      DOCKER_PLATFORMS: linux/amd64,linux/arm64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Download integrations
+        env:
+          # GITHUB_TOKEN is needed when -override-latest is used so we don't reach GH API rate limit
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: go run downloader.go -staging -override-latest -bundle=bundle-fips.yml -outdir=out-fips
+
+      - name: Run Trivy vulnerability scanner
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          image-ref: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_TAG }}
+          format: table
+          exit-code: 1
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
+          password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
+      - name: Build and push docker image
+        run: ./docker-build.sh . --push

--- a/.github/workflows/on-demand.yml
+++ b/.github/workflows/on-demand.yml
@@ -5,9 +5,6 @@ on:
       agent_version:
         description: "Agent version"
         required: true
-  push:
-    branches:
-      - NR-351464-add-fips-compliant-image
 jobs:
   build:
     name: Build and push image

--- a/.github/workflows/on-demand.yml
+++ b/.github/workflows/on-demand.yml
@@ -5,6 +5,9 @@ on:
       agent_version:
         description: "Agent version"
         required: true
+  push:
+    branches:
+      - NR-351464-add-fips-compliant-image
 jobs:
   build:
     name: Build and push image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,27 @@ jobs:
       bot_token: ${{ secrets.COREINT_BOT_TOKEN }}
       slack_channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
       slack_token: ${{ secrets.COREINT_SLACK_TOKEN }}
+
+  container-release-fips:
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3
+    with:
+      original_repo_name: 'newrelic/infrastructure-bundle'
+      docker_image_name: 'newrelic/infrastructure-bundle-fips'
+      
+      release_command_sh: |
+        go run downloader.go -bundle=bundle-fips.yml -outdir=out-fips
+        export DOCKER_PLATFORMS=linux/amd64,linux/arm64
+        export OUTDIR=out-fips
+        export BASE_IMAGE_NAME=newrelic/infrastructure-fips
+        ./docker-build.sh . --push
+        if [[ "${{ github.event.release.prerelease }}" == "false" ]]; then
+          export DOCKER_IMAGE_TAG=latest
+          ./docker-build.sh . --push
+        fi
+    
+    secrets:
+      docker_username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
+      docker_password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
+      bot_token: ${{ secrets.COREINT_BOT_TOKEN }}
+      slack_channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+      slack_token: ${{ secrets.COREINT_SLACK_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 out/
+out-fips/
 .idea
 /vendor
 /build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 
 ## Unreleased
+
+### enhancements
 - Added support for a FIPS compatible infrastructure bundle image
 
 ## v3.2.86 - 2025-09-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 
 ## Unreleased
+- Added support for a FIPS compatible infrastructure bundle image
 
 ## v3.2.86 - 2025-09-11
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG agent_version=latest
-ARG base_image=newrelic/infrastructure:${agent_version}
+ARG base_image_name=newrelic/infrastructure
+ARG base_image=${base_image_name}:${agent_version}
 
 # ephemeral building container
 FROM $base_image
@@ -8,9 +9,10 @@ FROM $base_image
 ARG TARGETOS
 ARG TARGETARCH
 ARG jre_version
+ARG out_dir
 
 # required for nri-jmx
 RUN if [ -n "${jre_version}" ]; then apk add --no-cache openjdk8-jre=${jre_version}; else apk add --no-cache openjdk8-jre; fi
 
 # integrations
-COPY out/${TARGETARCH} /
+COPY ${out_dir}/${TARGETARCH} /

--- a/bundle-fips.yml
+++ b/bundle-fips.yml
@@ -1,0 +1,90 @@
+# Version of the base agent image to use (`newrelic/infrastructure).
+# This is used by the `docker-build.sh` wrapper if AGENT_VERSION is not set
+agentVersion: 1.63.1
+
+# url, stagingUrl, and repo fields are compiled as templates. The `trimv` helper function can be used to remove the leading v
+# from a version string.
+
+# Used as defaults for all integrations below, can be overridden. Template.
+url: https://download.newrelic.com/infrastructure_agent/binaries/linux/{{.Arch}}/{{.Name}}-fips_linux_{{.Version | trimv}}_{{.Arch}}.tar.gz
+# stagingUrl will be used if the download is invoked with -staging. Template.
+stagingUrl: https://github.com/newrelic/{{.Name}}/releases/download/{{.Version}}/{{.Name}}-fips_linux_{{.Version | trimv}}_{{.Arch}}.tar.gz
+
+# List of architectures to fetch.
+archs: [ amd64, arm64 ]
+# GitHub repo hosting the integration. Used to fetch the latest available version when using -latest. Template.
+repo: newrelic/{{.Name}}
+
+# List of files to check for existence after integration has been unpacked. Template.
+testFiles:
+  # Test for existence of the main integation binary
+  - /var/db/newrelic-infra/newrelic-integrations/bin/{{.Name}}
+
+# List of integrations to download.
+# Individual entries may override any of the values defined above.
+integrations:
+#  - name: nri-apache
+#    version: 1.5.0
+#
+#    subpath: "" # Custom path to extract archive into. By default, it is assumed that the integration tarball is structured to be extracted in `/`.
+#    archReplacements: # Used as a key->value replacement when making the current arch from []archs available in {{.Arch}}. Useful for sketchy naming schemes.
+#      amd64: x86_64
+#
+#    # Overrides:
+#    archs: [] # Bundle this integration only in the specified architectures.
+#    url: "" # Defaults to global `url`, useful if tarballs have odd naming schemes.
+#    stagingUrl: "" # Defaults to global `stagingUrl`.
+#    repo: "" # Defaults to global `repo`.
+  - name: nri-apache
+    version: v1.14.0
+  # - name: nri-cassandra
+  #   version: v2.14.3
+  - name: nri-consul
+    version: v2.9.0
+  - name: nri-couchbase
+    version: v2.8.0
+  - name: nri-elasticsearch
+    version: v5.4.0
+  # - name: nri-f5
+  #   version: v2.8.3
+  - name: nri-haproxy
+    version: v3.2.0
+  # - name: nri-jmx
+  #   version: v3.8.1
+  #   testFiles:
+  #     - /opt/newrelic-infra/newrelic-integrations/bin/nri-jmx
+  # - name: nri-kafka
+  #   version: v3.10.2
+  - name: nri-memcached
+    version: v2.7.0
+  # - name: nri-mongodb
+  #   version: v2.9.2
+  - name: nri-mysql
+    version: v1.15.0
+  - name: nri-nagios
+    version: v2.11.0
+  - name: nri-nginx
+    version: v3.6.0
+  - name: nri-postgresql
+    version: v2.17.1
+  - name: nri-rabbitmq
+    version: v2.15.0
+  - name: nri-redis
+    version: v1.12.1
+  # - name: nrjmx
+  #   version: v2.7.0
+  #   url: https://download.newrelic.com/infrastructure_agent/binaries/linux/noarch/nrjmx_linux_{{.Version | trimv}}_noarch.tar.gz
+  #   stagingUrl: https://github.com/newrelic/{{.Name}}/releases/download/{{.Version}}/nrjmx_linux_{{.Version | trimv}}_noarch.tar.gz
+  #   testFiles:
+  #     - /usr/bin/nrjmx
+  - name: nri-discovery-kubernetes
+    version: v1.11.2
+    url: https://github.com/newrelic/{{.Name}}/releases/download/{{.Version}}/{{.Name}}-fips_{{.Version | trimv}}_Linux_{{.Arch}}.tar.gz
+    stagingUrl: https://github.com/newrelic/{{.Name}}/releases/download/{{.Version}}/{{.Name}}-fips_{{.Version | trimv}}_Linux_{{.Arch}}.tar.gz
+    subpath: var/db/newrelic-infra
+    archReplacements:
+      amd64: x86_64
+    testFiles:
+      - /var/db/newrelic-infra/nri-discovery-kubernetes
+  - name: nri-mssql
+    version: v2.17.2

--- a/bundle-fips.yml
+++ b/bundle-fips.yml
@@ -1,6 +1,6 @@
 # Version of the base agent image to use (`newrelic/infrastructure).
 # This is used by the `docker-build.sh` wrapper if AGENT_VERSION is not set
-agentVersion: 1.63.1
+agentVersion: 1.67.3
 
 # url, stagingUrl, and repo fields are compiled as templates. The `trimv` helper function can be used to remove the leading v
 # from a version string.
@@ -36,49 +36,49 @@ integrations:
 #    stagingUrl: "" # Defaults to global `stagingUrl`.
 #    repo: "" # Defaults to global `repo`.
   - name: nri-apache
-    version: v1.14.0
-  # - name: nri-cassandra
-  #   version: v2.14.3
-  - name: nri-consul
-    version: v2.9.0
-  - name: nri-couchbase
-    version: v2.8.0
-  - name: nri-elasticsearch
-    version: v5.4.0
-  # - name: nri-f5
-  #   version: v2.8.3
-  - name: nri-haproxy
-    version: v3.2.0
-  # - name: nri-jmx
-  #   version: v3.8.1
-  #   testFiles:
-  #     - /opt/newrelic-infra/newrelic-integrations/bin/nri-jmx
-  # - name: nri-kafka
-  #   version: v3.10.2
-  - name: nri-memcached
-    version: v2.7.0
-  # - name: nri-mongodb
-  #   version: v2.9.2
-  - name: nri-mysql
-    version: v1.15.0
-  - name: nri-nagios
-    version: v2.11.0
-  - name: nri-nginx
-    version: v3.6.0
-  - name: nri-postgresql
-    version: v2.17.1
-  - name: nri-rabbitmq
+    version: v1.15.2
+  - name: nri-cassandra
     version: v2.15.0
+  - name: nri-consul
+    version: v2.9.3
+  - name: nri-couchbase
+    version: v2.8.2
+  - name: nri-elasticsearch
+    version: v5.4.3
+  - name: nri-f5
+    version: v2.9.0
+  - name: nri-haproxy
+    version: v3.2.2
+  - name: nri-jmx
+    version: v3.9.0
+    testFiles:
+      - /opt/newrelic-infra/newrelic-integrations/bin/nri-jmx
+  - name: nri-kafka
+    version: v3.14.0
+  - name: nri-memcached
+    version: v2.7.2
+  - name: nri-mongodb
+    version: v2.9.4
+  - name: nri-mysql
+    version: v1.17.0
+  - name: nri-nagios
+    version: v2.11.2
+  - name: nri-nginx
+    version: v3.6.2
+  - name: nri-postgresql
+    version: v2.20.1
+  - name: nri-rabbitmq
+    version: v2.15.2
   - name: nri-redis
-    version: v1.12.1
-  # - name: nrjmx
-  #   version: v2.7.0
-  #   url: https://download.newrelic.com/infrastructure_agent/binaries/linux/noarch/nrjmx_linux_{{.Version | trimv}}_noarch.tar.gz
-  #   stagingUrl: https://github.com/newrelic/{{.Name}}/releases/download/{{.Version}}/nrjmx_linux_{{.Version | trimv}}_noarch.tar.gz
-  #   testFiles:
-  #     - /usr/bin/nrjmx
+    version: v1.12.3
+  - name: nrjmx
+    version: v2.10.1
+    url: https://download.newrelic.com/infrastructure_agent/binaries/linux/noarch/nrjmx-fips_linux_{{.Version | trimv}}_noarch.tar.gz
+    stagingUrl: https://github.com/newrelic/{{.Name}}/releases/download/{{.Version}}/nrjmx-fips_linux_{{.Version | trimv}}_noarch.tar.gz
+    testFiles:
+      - /usr/bin/nrjmx
   - name: nri-discovery-kubernetes
-    version: v1.11.2
+    version: v1.13.2
     url: https://github.com/newrelic/{{.Name}}/releases/download/{{.Version}}/{{.Name}}-fips_{{.Version | trimv}}_Linux_{{.Arch}}.tar.gz
     stagingUrl: https://github.com/newrelic/{{.Name}}/releases/download/{{.Version}}/{{.Name}}-fips_{{.Version | trimv}}_Linux_{{.Arch}}.tar.gz
     subpath: var/db/newrelic-infra
@@ -87,4 +87,4 @@ integrations:
     testFiles:
       - /var/db/newrelic-infra/nri-discovery-kubernetes
   - name: nri-mssql
-    version: v2.17.2
+    version: v2.20.3

--- a/bundle-fips.yml
+++ b/bundle-fips.yml
@@ -50,7 +50,7 @@ integrations:
   - name: nri-haproxy
     version: v3.2.2
   - name: nri-jmx
-    version: v3.9.0
+    version: v3.10.0
     testFiles:
       - /opt/newrelic-infra/newrelic-integrations/bin/nri-jmx
   - name: nri-kafka

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -6,6 +6,10 @@ DOCKER_PLATFORMS=${DOCKER_PLATFORMS:-linux/amd64,linux/arm64,linux/arm}
 JRE_VERSION=${JRE_VERSION:-} # Blank will pull default version for alpine image
 DOCKER_IMAGE=${DOCKER_IMAGE:-newrelic/infrastructure-bundle}
 DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-dev} # Overwritten by CI from the release tag
+OUTDIR=${OUTDIR:-out}
+BASE_IMAGE_NAME=${BASE_IMAGE_NAME:-newrelic/infrastructure}
+
+echo "base_image_name $BASE_IMAGE_NAME\n"
 
 # Get default AGENT_VERSION from downloader.go
 if [ -z "$AGENT_VERSION" ]; then
@@ -22,5 +26,7 @@ docker buildx build \
   --platform="${DOCKER_PLATFORMS}" \
   --build-arg agent_version="$AGENT_VERSION" \
   --build-arg jre_version="$JRE_VERSION" \
+  --build-arg out_dir="$OUTDIR"\
+  --build-arg base_image_name="$BASE_IMAGE_NAME" \
   -t "${DOCKER_IMAGE}:${DOCKER_IMAGE_TAG}" \
   "$@"

--- a/run-fips-ci-locally.sh
+++ b/run-fips-ci-locally.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+
+# This scripts runs something analogous to the CI locally, for reproducibility.
+# If $1 is set to release, it will run the release job with the docker account currently logged in
+
+echo "Downloading integrations..."
+rm -rf out-fips/ 2> /dev/null || true
+go run downloader.go -bundle=bundle-fips.yml -outdir=out-fips
+
+echo "Building image..."
+# Test build, but not load, for all archs
+OUTDIR=out-fips DOCKER_IMAGE=newrelic/infrastructure-bundle-fips BASE_IMAGE_NAME=newrelic/infrastructure-fips DOCKER_PLATFORMS=linux/amd64,linux/arm64 ./docker-build.sh .
+# Build and load for amd64 only (for snyk)
+OUTDIR=out-fips DOCKER_IMAGE=newrelic/infrastructure-bundle-fips BASE_IMAGE_NAME=newrelic/infrastructure-fips DOCKER_PLATFORMS=linux/amd64 ./docker-build.sh . --load
+
+if [[ -n "$SNYK_TOKEN" ]]; then
+    echo "Scanning Docker image ${DOCKER_IMAGE}:${DOCKER_IMAGE_TAG}..."
+    docker run -t -e "SNYK_TOKEN=${SNYK_TOKEN}" -v ${PWD}/workspace:/project -v "/var/run/docker.sock:/var/run/docker.sock" snyk/snyk-cli:docker monitor --docker "${DOCKER_IMAGE}:${DOCKER_IMAGE_TAG}" --severity-threshold=high --org=ohai  --project-name="${DOCKER_IMAGE}"
+else
+    echo "SNYK_TOKEN not defined, skipping snyk check"
+fi
+
+if [[ $1 == "release" ]]; then
+    if [[ -z ${DOCKER_IMAGE_TAG} ]]; then
+        echo "Refusing to push image with default tag. Please set the DOCKER_IMAGE_TAG env var."
+        exit 1
+    fi
+
+    echo
+    echo "Will now build and push ${DOCKER_IMAGE}:${DOCKER_IMAGE_TAG} as the user currently logged in in the docker CLI."
+    echo "If this is not what you want, press ^C within 5 seconds..."
+    echo
+    sleep 5
+    ./docker-build.sh . --push
+fi


### PR DESCRIPTION
Changes in this PRs - Build a fips compliant image `infrastructure-bundle-fips` which contains all fips complaint integrations and infra-agent.

<details><summary>Local Testing of building infrastructure-bundle-fips image</summary>
<p>

```shell
saanamsairajyadav@FDJV7H6TVP infrastructure-bundle % ./run-fips-ci-locally.sh
Downloading integrations...
2025/05/02 13:19:55 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-apache-fips_linux_1.14.0_amd64.tar.gz
2025/05/02 13:19:55 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-couchbase-fips_linux_2.8.0_amd64.tar.gz
2025/05/02 13:19:55 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-consul-fips_linux_2.9.0_amd64.tar.gz
2025/05/02 13:19:55 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-elasticsearch-fips_linux_5.4.0_amd64.tar.gz
2025/05/02 13:19:56 Downloading and extracting nri-apache (amd64)
2025/05/02 13:19:56 Downloading and extracting nri-consul (amd64)
2025/05/02 13:19:56 Downloading and extracting nri-elasticsearch (amd64)
2025/05/02 13:19:56 Downloading and extracting nri-couchbase (amd64)
2025/05/02 13:19:57 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-consul-fips_linux_2.9.0_arm64.tar.gz
2025/05/02 13:19:57 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-apache-fips_linux_1.14.0_arm64.tar.gz
2025/05/02 13:19:57 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-elasticsearch-fips_linux_5.4.0_arm64.tar.gz
2025/05/02 13:19:57 Downloading and extracting nri-consul (arm64)
2025/05/02 13:19:57 Downloading and extracting nri-apache (arm64)
2025/05/02 13:19:57 Downloading and extracting nri-elasticsearch (arm64)
2025/05/02 13:19:57 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-couchbase-fips_linux_2.8.0_arm64.tar.gz
2025/05/02 13:19:57 Downloading and extracting nri-couchbase (arm64)
2025/05/02 13:19:57 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-haproxy-fips_linux_3.2.0_amd64.tar.gz
2025/05/02 13:19:58 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-memcached-fips_linux_2.7.0_amd64.tar.gz
2025/05/02 13:19:58 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-mysql-fips_linux_1.15.0_amd64.tar.gz
2025/05/02 13:19:58 Downloading and extracting nri-haproxy (amd64)
2025/05/02 13:19:58 Downloading and extracting nri-memcached (amd64)
2025/05/02 13:19:58 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-nagios-fips_linux_2.11.0_amd64.tar.gz
2025/05/02 13:19:58 Downloading and extracting nri-mysql (amd64)
2025/05/02 13:19:58 Downloading and extracting nri-nagios (amd64)
2025/05/02 13:19:58 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-memcached-fips_linux_2.7.0_arm64.tar.gz
2025/05/02 13:19:58 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-nagios-fips_linux_2.11.0_arm64.tar.gz
2025/05/02 13:19:58 Downloading and extracting nri-memcached (arm64)
2025/05/02 13:19:59 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-haproxy-fips_linux_3.2.0_arm64.tar.gz
2025/05/02 13:19:59 Downloading and extracting nri-nagios (arm64)
2025/05/02 13:19:59 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-nginx-fips_linux_3.6.0_amd64.tar.gz
2025/05/02 13:19:59 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-mysql-fips_linux_1.15.0_arm64.tar.gz
2025/05/02 13:19:59 Downloading and extracting nri-haproxy (arm64)
2025/05/02 13:19:59 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-postgresql-fips_linux_2.17.1_amd64.tar.gz
2025/05/02 13:19:59 Downloading and extracting nri-nginx (amd64)
2025/05/02 13:19:59 Downloading and extracting nri-mysql (arm64)
2025/05/02 13:19:59 Downloading and extracting nri-postgresql (amd64)
2025/05/02 13:19:59 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-rabbitmq-fips_linux_2.15.0_amd64.tar.gz
2025/05/02 13:20:00 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-redis-fips_linux_1.12.1_amd64.tar.gz
2025/05/02 13:20:00 Downloading and extracting nri-rabbitmq (amd64)
2025/05/02 13:20:00 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-nginx-fips_linux_3.6.0_arm64.tar.gz
2025/05/02 13:20:00 Downloading and extracting nri-redis (amd64)
2025/05/02 13:20:00 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-postgresql-fips_linux_2.17.1_arm64.tar.gz
2025/05/02 13:20:00 Downloading and extracting nri-nginx (arm64)
2025/05/02 13:20:00 Downloading and extracting nri-postgresql (arm64)
2025/05/02 13:20:01 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-redis-fips_linux_1.12.1_arm64.tar.gz
2025/05/02 13:20:01 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-rabbitmq-fips_linux_2.15.0_arm64.tar.gz
2025/05/02 13:20:01 Downloading and extracting nri-redis (arm64)
2025/05/02 13:20:01 Downloading https://github.com/newrelic/nri-discovery-kubernetes/releases/download/v1.11.2/nri-discovery-kubernetes-fips_1.11.2_Linux_x86_64.tar.gz
2025/05/02 13:20:01 Downloading and extracting nri-rabbitmq (arm64)
2025/05/02 13:20:01 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-mssql-fips_linux_2.17.2_amd64.tar.gz
2025/05/02 13:20:01 Downloading and extracting nri-mssql (amd64)
2025/05/02 13:20:02 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-mssql-fips_linux_2.17.2_arm64.tar.gz
2025/05/02 13:20:03 Downloading and extracting nri-mssql (arm64)
2025/05/02 13:20:03 Downloading and extracting nri-discovery-kubernetes (amd64)
2025/05/02 13:20:04 Downloading https://github.com/newrelic/nri-discovery-kubernetes/releases/download/v1.11.2/nri-discovery-kubernetes-fips_1.11.2_Linux_arm64.tar.gz
2025/05/02 13:20:05 Downloading and extracting nri-discovery-kubernetes (arm64)
2025/05/02 13:20:06 Preparing tree for install...
2025/05/02 13:20:06 Checking files for existence...
2025/05/02 13:20:06 All done, integrations installed to 'out-fips'
Building image...
base_image_name newrelic/infrastructure-fips

Building the image leveraging agent_version=1.63.1
[+] Building 23.5s (14/14) FINISHED                                                                                                    docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                   0.0s
 => => transferring dockerfile: 559B                                                                                                                   0.0s
 => [linux/arm64 internal] load metadata for docker.io/newrelic/infrastructure-fips:1.63.1                                                             3.4s
 => [linux/amd64 internal] load metadata for docker.io/newrelic/infrastructure-fips:1.63.1                                                             2.2s
 => [auth] newrelic/infrastructure-fips:pull token for registry-1.docker.io                                                                            0.0s
 => [internal] load .dockerignore                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                        0.0s
 => [linux/arm64 1/3] FROM docker.io/newrelic/infrastructure-fips:1.63.1@sha256:8a23394a953aaf9e8b6a6ed511fc2dfe7dd11128166e3494fa6dfab77b5eadb6       7.8s
 => => resolve docker.io/newrelic/infrastructure-fips:1.63.1@sha256:8a23394a953aaf9e8b6a6ed511fc2dfe7dd11128166e3494fa6dfab77b5eadb6                   0.0s
 => => sha256:2f07f3a2af2b9027dbbb16309bce4c9da3697b57bc1d8fb1701835ea2122dcc9 29.38MB / 29.38MB                                                       5.0s
 => => sha256:9a6238ff7a9afd97fd8336bb63d71c0c83f16ac5563967e4d59a6c827eaa4ab6 18.89MB / 18.89MB                                                       7.1s
 => => sha256:2835c97cdda605068132160bdd73739d9b2f8b1302bd590e1b2ddda504bdb97c 348.97kB / 348.97kB                                                     1.3s
 => => sha256:2617104719138edf6db1b972d10575b285483a7400b5b480599e771f51677fbf 7.92kB / 7.92kB                                                         1.2s
 => => sha256:041f547f90049ac847974160c37ed51c1b8b17cee186e50c42309bda753c883f 156B / 156B                                                             1.1s
 => => sha256:e989c7b45f9ab0648b1cc0117abaa8cb927161e0f85c5c0aec3f7e02db33dbe0 2.69kB / 2.69kB                                                         1.0s
 => => sha256:6458d450a086acc7f4b7bdfe26f97f48784ab82c76dd91eb4e9599acf70309fd 6.74MB / 6.74MB                                                         2.7s
 => => sha256:5b5c40cdb42fec5955d575398b352f23650a84dfdbff48945b9831ed845fe1dd 1.97MB / 1.97MB                                                         1.7s
 => => sha256:b8d074770eeaaef008d804d394889afe12b6628083ceb4e516bbf5071336deee 9.13MB / 9.13MB                                                         1.7s
 => => extracting sha256:b8d074770eeaaef008d804d394889afe12b6628083ceb4e516bbf5071336deee                                                              0.1s
 => => extracting sha256:6458d450a086acc7f4b7bdfe26f97f48784ab82c76dd91eb4e9599acf70309fd                                                              0.1s
 => => extracting sha256:5b5c40cdb42fec5955d575398b352f23650a84dfdbff48945b9831ed845fe1dd                                                              0.0s
 => => extracting sha256:e989c7b45f9ab0648b1cc0117abaa8cb927161e0f85c5c0aec3f7e02db33dbe0                                                              0.0s
 => => extracting sha256:041f547f90049ac847974160c37ed51c1b8b17cee186e50c42309bda753c883f                                                              0.0s
 => => extracting sha256:2617104719138edf6db1b972d10575b285483a7400b5b480599e771f51677fbf                                                              0.0s
 => => extracting sha256:2835c97cdda605068132160bdd73739d9b2f8b1302bd590e1b2ddda504bdb97c                                                              0.0s
 => => extracting sha256:9a6238ff7a9afd97fd8336bb63d71c0c83f16ac5563967e4d59a6c827eaa4ab6                                                              0.2s
 => => extracting sha256:2f07f3a2af2b9027dbbb16309bce4c9da3697b57bc1d8fb1701835ea2122dcc9                                                              0.2s
 => [internal] load build context                                                                                                                      0.5s
 => => transferring context: 128.04MB                                                                                                                  0.5s
 => [internal] load build context                                                                                                                      0.1s
 => => transferring context: 17.31MB                                                                                                                   0.1s
 => [linux/amd64 1/3] FROM docker.io/newrelic/infrastructure-fips:1.63.1@sha256:8a23394a953aaf9e8b6a6ed511fc2dfe7dd11128166e3494fa6dfab77b5eadb6       0.0s
 => => resolve docker.io/newrelic/infrastructure-fips:1.63.1@sha256:8a23394a953aaf9e8b6a6ed511fc2dfe7dd11128166e3494fa6dfab77b5eadb6                   0.0s
 => CACHED [linux/amd64 2/3] RUN if [ -n "" ]; then apk add --no-cache openjdk8-jre=; else apk add --no-cache openjdk8-jre; fi                         0.0s
 => [linux/amd64 3/3] COPY out-fips/amd64 /                                                                                                            0.2s
 => [linux/arm64 2/3] RUN if [ -n "" ]; then apk add --no-cache openjdk8-jre=; else apk add --no-cache openjdk8-jre; fi                                7.9s
 => [linux/arm64 3/3] COPY out-fips/arm64 /                                                                                                            0.1s 
 => exporting to image                                                                                                                                 4.2s 
 => => exporting layers                                                                                                                                3.4s 
 => => exporting manifest sha256:98fe4e8c26ca4765da69bef68a5479a06b398c026dd5bde786ed2efc7275724f                                                      0.0s 
 => => exporting config sha256:744d048ab52284415b04b9909f7bf26b049d0e70f4a817cd9284a839c40920e5                                                        0.0s 
 => => exporting attestation manifest sha256:b6d7b64b48862dba2a5852c1f24721b20efd1e3d84371880d3c5d9daf489017b                                          0.0s 
 => => exporting manifest sha256:cea4b260eb10cbde567fbffea14adcf909bc39da537f1eeb26249c67579f9a8c                                                      0.0s
 => => exporting config sha256:cc09ab7149334d1c7589148cb6fd23745fafe1038427786e4204a586e101824c                                                        0.0s
 => => exporting attestation manifest sha256:4058bc40401686a17938fac47b02ca757edf677536e6ded30b2d73b100e6ef2e                                          0.0s
 => => exporting manifest list sha256:9b737efdd4a21021915c4e36d4b5525adb4fe6dab2724bb2b4d34b7c02705b27                                                 0.0s
 => => naming to docker.io/newrelic/infrastructure-bundle-fips:dev                                                                                     0.0s
 => => unpacking to docker.io/newrelic/infrastructure-bundle-fips:dev                                                                                  0.7s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/qg95xcjhbk4djfbqkz0dbth3s

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview 
base_image_name newrelic/infrastructure-fips

Building the image leveraging agent_version=1.63.1
[+] Building 1.6s (8/8) FINISHED                                                                                                       docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                   0.0s
 => => transferring dockerfile: 559B                                                                                                                   0.0s
 => [internal] load metadata for docker.io/newrelic/infrastructure-fips:1.63.1                                                                         1.1s
 => [internal] load .dockerignore                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                        0.0s
 => [1/3] FROM docker.io/newrelic/infrastructure-fips:1.63.1@sha256:8a23394a953aaf9e8b6a6ed511fc2dfe7dd11128166e3494fa6dfab77b5eadb6                   0.0s
 => => resolve docker.io/newrelic/infrastructure-fips:1.63.1@sha256:8a23394a953aaf9e8b6a6ed511fc2dfe7dd11128166e3494fa6dfab77b5eadb6                   0.0s
 => [internal] load build context                                                                                                                      0.4s
 => => transferring context: 138.66MB                                                                                                                  0.4s
 => CACHED [2/3] RUN if [ -n "" ]; then apk add --no-cache openjdk8-jre=; else apk add --no-cache openjdk8-jre; fi                                     0.0s
 => CACHED [3/3] COPY out-fips/amd64 /                                                                                                                 0.0s
 => exporting to image                                                                                                                                 0.0s
 => => exporting layers                                                                                                                                0.0s
 => => exporting manifest sha256:98fe4e8c26ca4765da69bef68a5479a06b398c026dd5bde786ed2efc7275724f                                                      0.0s
 => => exporting config sha256:744d048ab52284415b04b9909f7bf26b049d0e70f4a817cd9284a839c40920e5                                                        0.0s
 => => exporting attestation manifest sha256:be79159764b71a0065f4c3b78894df84aff7a31067809e38f524045e11b331fe                                          0.0s
 => => exporting manifest list sha256:c779756bdedb79b18e6f99c980f7e396cbdea4d084ff5fca3f500e6d9a062977                                                 0.0s
 => => naming to docker.io/newrelic/infrastructure-bundle-fips:dev                                                                                     0.0s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/p5k9zk8s4poaqmhh5mp4z6c8v

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview 
SNYK_TOKEN not defined, skipping snyk check
saanamsairajyadav@FDJV7H6TVP infrastructure-bundle % 
``` 
</p>
</details> 


<details><summary>Local testing of building infrastructure-bundle image</summary>
<p>

```shell
saanamsairajyadav@FDJV7H6TVP infrastructure-bundle % ./run-ci-locally.sh 
Downloading integrations...
2025/05/02 13:23:19 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-apache_linux_1.14.0_amd64.tar.gz
2025/05/02 13:23:19 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-couchbase_linux_2.8.0_amd64.tar.gz
2025/05/02 13:23:19 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-consul_linux_2.9.0_amd64.tar.gz
2025/05/02 13:23:19 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-cassandra_linux_2.14.3_amd64.tar.gz
2025/05/02 13:23:19 Downloading and extracting nri-consul (amd64)
2025/05/02 13:23:19 Downloading and extracting nri-cassandra (amd64)
2025/05/02 13:23:19 Downloading and extracting nri-couchbase (amd64)
2025/05/02 13:23:20 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-cassandra_linux_2.14.3_arm.tar.gz
2025/05/02 13:23:20 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-couchbase_linux_2.8.0_arm.tar.gz
2025/05/02 13:23:20 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-consul_linux_2.9.0_arm.tar.gz
2025/05/02 13:23:20 Downloading and extracting nri-cassandra (arm)
2025/05/02 13:23:20 Downloading and extracting nri-apache (amd64)
2025/05/02 13:23:21 Downloading and extracting nri-couchbase (arm)
2025/05/02 13:23:21 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-cassandra_linux_2.14.3_arm64.tar.gz
2025/05/02 13:23:21 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-apache_linux_1.14.0_arm.tar.gz
2025/05/02 13:23:21 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-couchbase_linux_2.8.0_arm64.tar.gz
2025/05/02 13:23:21 Downloading and extracting nri-consul (arm)
2025/05/02 13:23:22 Downloading and extracting nri-apache (arm)
2025/05/02 13:23:22 Downloading and extracting nri-couchbase (arm64)
2025/05/02 13:23:22 Downloading and extracting nri-cassandra (arm64)
2025/05/02 13:23:22 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-consul_linux_2.9.0_arm64.tar.gz
2025/05/02 13:23:22 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-apache_linux_1.14.0_arm64.tar.gz
2025/05/02 13:23:22 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-elasticsearch_linux_5.4.0_amd64.tar.gz
2025/05/02 13:23:23 Downloading and extracting nri-apache (arm64)
2025/05/02 13:23:23 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-f5_linux_2.8.3_amd64.tar.gz
2025/05/02 13:23:23 Downloading and extracting nri-elasticsearch (amd64)
2025/05/02 13:23:23 Downloading and extracting nri-f5 (amd64)
2025/05/02 13:23:23 Downloading and extracting nri-consul (arm64)
2025/05/02 13:23:23 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-elasticsearch_linux_5.4.0_arm.tar.gz
2025/05/02 13:23:24 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-haproxy_linux_3.2.0_amd64.tar.gz
2025/05/02 13:23:24 Downloading and extracting nri-elasticsearch (arm)
2025/05/02 13:23:24 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-jmx_linux_3.8.1_amd64.tar.gz
2025/05/02 13:23:24 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-f5_linux_2.8.3_arm.tar.gz
2025/05/02 13:23:24 Downloading and extracting nri-haproxy (amd64)
2025/05/02 13:23:24 Downloading and extracting nri-jmx (amd64)
2025/05/02 13:23:24 Downloading and extracting nri-f5 (arm)
2025/05/02 13:23:25 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-haproxy_linux_3.2.0_arm.tar.gz
2025/05/02 13:23:25 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-elasticsearch_linux_5.4.0_arm64.tar.gz
2025/05/02 13:23:25 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-jmx_linux_3.8.1_arm.tar.gz
2025/05/02 13:23:25 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-f5_linux_2.8.3_arm64.tar.gz
2025/05/02 13:23:25 Downloading and extracting nri-elasticsearch (arm64)
2025/05/02 13:23:25 Downloading and extracting nri-haproxy (arm)
2025/05/02 13:23:25 Downloading and extracting nri-jmx (arm)
2025/05/02 13:23:26 Downloading and extracting nri-f5 (arm64)
2025/05/02 13:23:26 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-haproxy_linux_3.2.0_arm64.tar.gz
2025/05/02 13:23:26 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-kafka_linux_3.10.2_amd64.tar.gz
2025/05/02 13:23:26 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-jmx_linux_3.8.1_arm64.tar.gz
2025/05/02 13:23:26 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-memcached_linux_2.7.0_amd64.tar.gz
2025/05/02 13:23:26 Downloading and extracting nri-kafka (amd64)
2025/05/02 13:23:26 Downloading and extracting nri-haproxy (arm64)
2025/05/02 13:23:27 Downloading and extracting nri-jmx (arm64)
2025/05/02 13:23:27 Downloading and extracting nri-memcached (amd64)
2025/05/02 13:23:27 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-mongodb_linux_2.9.2_amd64.tar.gz
2025/05/02 13:23:27 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-memcached_linux_2.7.0_arm.tar.gz
2025/05/02 13:23:27 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-mysql_linux_1.14.1_amd64.tar.gz
2025/05/02 13:23:27 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-kafka_linux_3.10.2_arm.tar.gz
2025/05/02 13:23:28 Downloading and extracting nri-memcached (arm)
2025/05/02 13:23:28 Downloading and extracting nri-mysql (amd64)
2025/05/02 13:23:28 Downloading and extracting nri-kafka (arm)
2025/05/02 13:23:28 Downloading and extracting nri-mongodb (amd64)
2025/05/02 13:23:28 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-memcached_linux_2.7.0_arm64.tar.gz
2025/05/02 13:23:28 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-mysql_linux_1.14.1_arm.tar.gz
2025/05/02 13:23:29 Downloading and extracting nri-memcached (arm64)
2025/05/02 13:23:29 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-mongodb_linux_2.9.2_arm.tar.gz
2025/05/02 13:23:29 Downloading and extracting nri-mysql (arm)
2025/05/02 13:23:29 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-kafka_linux_3.10.2_arm64.tar.gz
2025/05/02 13:23:29 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-nagios_linux_2.11.0_amd64.tar.gz
2025/05/02 13:23:29 Downloading and extracting nri-mongodb (arm)
2025/05/02 13:23:29 Downloading and extracting nri-nagios (amd64)
2025/05/02 13:23:29 Downloading and extracting nri-kafka (arm64)
2025/05/02 13:23:30 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-mysql_linux_1.14.1_arm64.tar.gz
2025/05/02 13:23:30 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-nagios_linux_2.11.0_arm.tar.gz
2025/05/02 13:23:30 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-mongodb_linux_2.9.2_arm64.tar.gz
2025/05/02 13:23:30 Downloading and extracting nri-mysql (arm64)
2025/05/02 13:23:30 Downloading and extracting nri-nagios (arm)
2025/05/02 13:23:30 Downloading and extracting nri-mongodb (arm64)
2025/05/02 13:23:31 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-nagios_linux_2.11.0_arm64.tar.gz
2025/05/02 13:23:31 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-nginx_linux_3.6.0_amd64.tar.gz
2025/05/02 13:23:31 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-postgresql_linux_2.17.1_amd64.tar.gz
2025/05/02 13:23:31 Downloading and extracting nri-nginx (amd64)
2025/05/02 13:23:31 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-rabbitmq_linux_2.15.0_amd64.tar.gz
2025/05/02 13:23:31 Downloading and extracting nri-nagios (arm64)
2025/05/02 13:23:31 Downloading and extracting nri-postgresql (amd64)
2025/05/02 13:23:32 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-redis_linux_1.12.1_amd64.tar.gz
2025/05/02 13:23:32 Downloading and extracting nri-rabbitmq (amd64)
2025/05/02 13:23:32 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-nginx_linux_3.6.0_arm.tar.gz
2025/05/02 13:23:32 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-postgresql_linux_2.17.1_arm.tar.gz
2025/05/02 13:23:32 Downloading and extracting nri-redis (amd64)
2025/05/02 13:23:32 Downloading and extracting nri-nginx (arm)
2025/05/02 13:23:32 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-rabbitmq_linux_2.15.0_arm.tar.gz
2025/05/02 13:23:33 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-redis_linux_1.12.1_arm.tar.gz
2025/05/02 13:23:33 Downloading and extracting nri-postgresql (arm)
2025/05/02 13:23:33 Downloading and extracting nri-rabbitmq (arm)
2025/05/02 13:23:33 Downloading and extracting nri-redis (arm)
2025/05/02 13:23:33 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-nginx_linux_3.6.0_arm64.tar.gz
2025/05/02 13:23:33 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-redis_linux_1.12.1_arm64.tar.gz
2025/05/02 13:23:33 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-postgresql_linux_2.17.1_arm64.tar.gz
2025/05/02 13:23:34 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-rabbitmq_linux_2.15.0_arm64.tar.gz
2025/05/02 13:23:34 Downloading and extracting nri-nginx (arm64)
2025/05/02 13:23:34 Downloading and extracting nri-redis (arm64)
2025/05/02 13:23:34 Downloading and extracting nri-postgresql (arm64)
2025/05/02 13:23:34 Downloading and extracting nri-rabbitmq (arm64)
2025/05/02 13:23:34 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/noarch/nrjmx_linux_2.7.0_noarch.tar.gz
2025/05/02 13:23:34 Downloading https://github.com/newrelic/nri-discovery-kubernetes/releases/download/v1.11.1/nri-discovery-kubernetes_1.11.1_Linux_x86_64.tar.gz
2025/05/02 13:23:35 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/amd64/nri-mssql_linux_2.17.2_amd64.tar.gz
2025/05/02 13:23:35 Downloading and extracting nrjmx (amd64)
2025/05/02 13:23:35 Downloading and extracting nri-mssql (amd64)
2025/05/02 13:23:36 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/noarch/nrjmx_linux_2.7.0_noarch.tar.gz
2025/05/02 13:23:36 Downloading and extracting nrjmx (arm)
2025/05/02 13:23:36 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/noarch/nrjmx_linux_2.7.0_noarch.tar.gz
2025/05/02 13:23:36 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm/nri-mssql_linux_2.17.2_arm.tar.gz
2025/05/02 13:23:36 Downloading and extracting nrjmx (arm64)
2025/05/02 13:23:36 Downloading and extracting nri-discovery-kubernetes (amd64)
2025/05/02 13:23:36 Downloading and extracting nri-mssql (arm)
2025/05/02 13:23:37 Downloading https://download.newrelic.com/infrastructure_agent/binaries/linux/arm64/nri-mssql_linux_2.17.2_arm64.tar.gz
2025/05/02 13:23:38 Downloading https://github.com/newrelic/nri-discovery-kubernetes/releases/download/v1.11.1/nri-discovery-kubernetes_1.11.1_Linux_arm.tar.gz
2025/05/02 13:23:38 Downloading and extracting nri-mssql (arm64)
2025/05/02 13:23:39 Downloading and extracting nri-discovery-kubernetes (arm)
2025/05/02 13:23:41 Downloading https://github.com/newrelic/nri-discovery-kubernetes/releases/download/v1.11.1/nri-discovery-kubernetes_1.11.1_Linux_arm64.tar.gz
2025/05/02 13:23:42 Downloading and extracting nri-discovery-kubernetes (arm64)
2025/05/02 13:23:44 Preparing tree for install...
2025/05/02 13:23:44 Checking files for existence...
2025/05/02 13:23:44 All done, integrations installed to 'out'
Building image...
base_image_name newrelic/infrastructure

Building the image leveraging agent_version=1.63.1
[+] Building 34.5s (19/19) FINISHED                                                                                                    docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                   0.0s
 => => transferring dockerfile: 559B                                                                                                                   0.0s
 => [linux/arm/v7 internal] load metadata for docker.io/newrelic/infrastructure:1.63.1                                                                 3.5s
 => [linux/arm64 internal] load metadata for docker.io/newrelic/infrastructure:1.63.1                                                                  3.1s
 => [linux/amd64 internal] load metadata for docker.io/newrelic/infrastructure:1.63.1                                                                  2.2s
 => [auth] newrelic/infrastructure:pull token for registry-1.docker.io                                                                                 0.0s
 => [internal] load .dockerignore                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                        0.0s
 => [linux/arm64 1/3] FROM docker.io/newrelic/infrastructure:1.63.1@sha256:4c08af8bef6a82789a888244e5474b57f6f2fe8b83659295bbd39c19bb569b21            7.0s
 => => resolve docker.io/newrelic/infrastructure:1.63.1@sha256:4c08af8bef6a82789a888244e5474b57f6f2fe8b83659295bbd39c19bb569b21                        0.0s
 => => sha256:c0dbafdeef41f4713e317d56d54ecb00ae77159af0e3736ae36a238c88ab6495 27.20MB / 27.20MB                                                       3.8s
 => => sha256:1d25f8350ed9bee8c41b13d806711b793c0f9ecdeb972d00a71fcae62b43f6dc 18.89MB / 18.89MB                                                       4.4s
 => => sha256:b765108c16d8f1e474d97469c63edb33687bc105b81dee928c14820fcfa9d768 348.97kB / 348.97kB                                                     0.4s
 => => sha256:26f3aca6f2c87d93862f36a83dc31ab438cb8cee5f240ecb00ccee6c21bc80c8 7.92kB / 7.92kB                                                         1.0s
 => => sha256:9c9f90349aadeb508d1caf85ab9b13da1cc56309f985037b3799d9ecda6e4484 156B / 156B                                                             0.6s
 => => sha256:607c0bb24cf2439f3be8faee1596c76be20fa53d07098123266623c811f28f49 2.69kB / 2.69kB                                                         0.7s
 => => sha256:95bdc3c67592560c67233a9c68a71b18a9f15ec70a1586d48dae2be4fad8ea55 1.32MB / 1.32MB                                                         2.4s
 => => sha256:1f1bfc314023fe3de43918545796522bed4d2953d991d01b2e8a843d2063e624 6.04MB / 6.04MB                                                         4.5s
 => => sha256:b239a680dc81e96da49c1d627956c2f0fe951696a8cf341254458aaeedc26fdf 8.44MB / 8.44MB                                                         2.2s
 => => extracting sha256:b239a680dc81e96da49c1d627956c2f0fe951696a8cf341254458aaeedc26fdf                                                              0.1s
 => => extracting sha256:1f1bfc314023fe3de43918545796522bed4d2953d991d01b2e8a843d2063e624                                                              0.1s
 => => extracting sha256:95bdc3c67592560c67233a9c68a71b18a9f15ec70a1586d48dae2be4fad8ea55                                                              0.0s
 => => extracting sha256:607c0bb24cf2439f3be8faee1596c76be20fa53d07098123266623c811f28f49                                                              0.0s
 => => extracting sha256:9c9f90349aadeb508d1caf85ab9b13da1cc56309f985037b3799d9ecda6e4484                                                              0.0s
 => => extracting sha256:26f3aca6f2c87d93862f36a83dc31ab438cb8cee5f240ecb00ccee6c21bc80c8                                                              0.0s
 => => extracting sha256:b765108c16d8f1e474d97469c63edb33687bc105b81dee928c14820fcfa9d768                                                              0.0s
 => => extracting sha256:1d25f8350ed9bee8c41b13d806711b793c0f9ecdeb972d00a71fcae62b43f6dc                                                              0.2s
 => => extracting sha256:c0dbafdeef41f4713e317d56d54ecb00ae77159af0e3736ae36a238c88ab6495                                                              0.2s
 => CACHED [linux/amd64 1/3] FROM docker.io/newrelic/infrastructure:1.63.1@sha256:4c08af8bef6a82789a888244e5474b57f6f2fe8b83659295bbd39c19bb569b21     0.1s
 => => resolve docker.io/newrelic/infrastructure:1.63.1@sha256:4c08af8bef6a82789a888244e5474b57f6f2fe8b83659295bbd39c19bb569b21                        0.0s
 => [internal] load build context                                                                                                                      1.3s
 => => transferring context: 150.50MB                                                                                                                  1.3s
 => [linux/arm/v7 1/3] FROM docker.io/newrelic/infrastructure:1.63.1@sha256:4c08af8bef6a82789a888244e5474b57f6f2fe8b83659295bbd39c19bb569b21          12.6s
 => => resolve docker.io/newrelic/infrastructure:1.63.1@sha256:4c08af8bef6a82789a888244e5474b57f6f2fe8b83659295bbd39c19bb569b21                        0.0s
 => => sha256:3b45a11a659c05483c9bf712aaec49aa596dd07b43b96f75c34ffa857a4d45b3 28.67MB / 28.67MB                                                       4.5s
 => => sha256:12d2d4a8797c23177e4feaa51a7cf46244668e808ca6426a1100f63ab112106e 328.52kB / 328.52kB                                                     1.2s
 => => sha256:cfeb516edbd055eb0349e4e52f31d4cf1943c7675ddbd1cac8389fee5e464a21 17.79MB / 17.79MB                                                       6.3s
 => => sha256:26c7314fb8bd55fe1016e6729e3fd99aabb3db3ded0f4c6d55cba79dc13e84d1 7.92kB / 7.92kB                                                         0.6s
 => => sha256:d8310a6a96b9ee79f547c21489d66e8f63b5474f9cbee57545dec42cca9c0727 156B / 156B                                                             0.6s
 => => sha256:2c0e29bf7a8e15233f00b5ccb569f004435d9606d21b36f30084ca11a864cc5a 2.70kB / 2.70kB                                                         0.8s
 => => sha256:2f4ca0fa3363bd05cc8abff5fe56af4e82b44ac6101e9b420c4531ebcba038c4 1.25MB / 1.25MB                                                         2.5s
 => => sha256:4523465b2894a5664785fc23ba029be578a9e6c7bee5ba39cdd01162e9b1dff4 6.25MB / 6.25MB                                                         2.6s
 => => sha256:ba02e39b8822dcd6735e44d61299e343ccea5c5d6bb84b4a35d76d60b79bf63c 8.67MB / 8.67MB                                                         2.2s
 => => sha256:85f3b18f9f5a8655db86c6dfb02bb01011ffef63d10a173843c5c65c3e9137b7 3.10MB / 3.10MB                                                         2.1s
 => => extracting sha256:85f3b18f9f5a8655db86c6dfb02bb01011ffef63d10a173843c5c65c3e9137b7                                                              0.0s
 => => extracting sha256:ba02e39b8822dcd6735e44d61299e343ccea5c5d6bb84b4a35d76d60b79bf63c                                                              0.1s
 => => extracting sha256:4523465b2894a5664785fc23ba029be578a9e6c7bee5ba39cdd01162e9b1dff4                                                              0.1s
 => => extracting sha256:2f4ca0fa3363bd05cc8abff5fe56af4e82b44ac6101e9b420c4531ebcba038c4                                                              0.0s
 => => extracting sha256:2c0e29bf7a8e15233f00b5ccb569f004435d9606d21b36f30084ca11a864cc5a                                                              0.0s
 => => extracting sha256:d8310a6a96b9ee79f547c21489d66e8f63b5474f9cbee57545dec42cca9c0727                                                              0.0s
 => => extracting sha256:26c7314fb8bd55fe1016e6729e3fd99aabb3db3ded0f4c6d55cba79dc13e84d1                                                              0.0s
 => => extracting sha256:12d2d4a8797c23177e4feaa51a7cf46244668e808ca6426a1100f63ab112106e                                                              0.0s
 => => extracting sha256:cfeb516edbd055eb0349e4e52f31d4cf1943c7675ddbd1cac8389fee5e464a21                                                              0.2s
 => => extracting sha256:3b45a11a659c05483c9bf712aaec49aa596dd07b43b96f75c34ffa857a4d45b3                                                              0.2s
 => [internal] load build context                                                                                                                      1.3s
 => => transferring context: 146.05MB                                                                                                                  1.3s
 => [internal] load build context                                                                                                                      1.3s
 => => transferring context: 145.19MB                                                                                                                  1.3s
 => [linux/amd64 2/3] RUN if [ -n "" ]; then apk add --no-cache openjdk8-jre=; else apk add --no-cache openjdk8-jre; fi                               25.5s
 => [linux/arm64 2/3] RUN if [ -n "" ]; then apk add --no-cache openjdk8-jre=; else apk add --no-cache openjdk8-jre; fi                               17.8s
 => [linux/arm/v7 2/3] RUN if [ -n "" ]; then apk add --no-cache openjdk8-jre=; else apk add --no-cache openjdk8-jre; fi                              13.3s
 => [linux/arm64 3/3] COPY out/arm64 /                                                                                                                 0.1s
 => [linux/amd64 3/3] COPY out/amd64 /                                                                                                                 0.1s
 => [linux/arm/v7 3/3] COPY out/arm /                                                                                                                  0.1s
 => exporting to image                                                                                                                                 4.9s
 => => exporting layers                                                                                                                                4.0s
 => => exporting manifest sha256:8e6baa3ead3c672f6bdd44c20e7e979d9863f88f6c4a74e97cf9200c2fa8525d                                                      0.0s
 => => exporting config sha256:b302b8a7425e0d7bec146d759a69dd5901fe22d66602afd6f3fddf1c2dc0ed46                                                        0.0s
 => => exporting attestation manifest sha256:bfdbebddd10afafffd00603d412acc294cf4ef12b430861735e0fb46b7a3bd87                                          0.0s
 => => exporting manifest sha256:7f26f81f3a2f2d991f20350e93c64eca58c07bfd84b127512ebdbfc99c4dfaa7                                                      0.0s
 => => exporting config sha256:4ac92b611e2cb5124bbb4091fbfd8ad34aefff23f618a35b7e8706869d0d5e3f                                                        0.0s
 => => exporting attestation manifest sha256:903a7693edd57cf91f6209c6ebf169fcd87bf774b09018f8d8a94e5f0471c614                                          0.0s
 => => exporting manifest sha256:4b581b9cbfee6db8192d96a88f7ffe34b1c570a5381f3141e111f9c292de221b                                                      0.0s
 => => exporting config sha256:c933bcf2613cc96f5a08a69004914bb7f2a24d1a3ed9469d517d61ab033bd70e                                                        0.0s
 => => exporting attestation manifest sha256:c1c25ffb2139f3c1e67e1fc6e436a1c3287debf6334cfb0f70869a93ddc8fe9e                                          0.0s
 => => exporting manifest list sha256:e1a3b7dd8205bbbbb3d2862bab4a56fd627af6b31a27b610e8d3d3868ea7d871                                                 0.0s
 => => naming to docker.io/newrelic/infrastructure-bundle:dev                                                                                          0.0s
 => => unpacking to docker.io/newrelic/infrastructure-bundle:dev                                                                                       0.8s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/8vm8k45etv4pk190ax26p533x

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview 
base_image_name newrelic/infrastructure

Building the image leveraging agent_version=1.63.1
[+] Building 1.1s (8/8) FINISHED                                                                                                       docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                   0.0s
 => => transferring dockerfile: 559B                                                                                                                   0.0s
 => [internal] load metadata for docker.io/newrelic/infrastructure:1.63.1                                                                              1.0s
 => [internal] load .dockerignore                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                        0.0s
 => [1/3] FROM docker.io/newrelic/infrastructure:1.63.1@sha256:4c08af8bef6a82789a888244e5474b57f6f2fe8b83659295bbd39c19bb569b21                        0.0s
 => => resolve docker.io/newrelic/infrastructure:1.63.1@sha256:4c08af8bef6a82789a888244e5474b57f6f2fe8b83659295bbd39c19bb569b21                        0.0s
 => [internal] load build context                                                                                                                      0.0s
 => => transferring context: 4.72kB                                                                                                                    0.0s
 => CACHED [2/3] RUN if [ -n "" ]; then apk add --no-cache openjdk8-jre=; else apk add --no-cache openjdk8-jre; fi                                     0.0s
 => CACHED [3/3] COPY out/amd64 /                                                                                                                      0.0s
 => exporting to image                                                                                                                                 0.0s
 => => exporting layers                                                                                                                                0.0s
 => => exporting manifest sha256:8e6baa3ead3c672f6bdd44c20e7e979d9863f88f6c4a74e97cf9200c2fa8525d                                                      0.0s
 => => exporting config sha256:b302b8a7425e0d7bec146d759a69dd5901fe22d66602afd6f3fddf1c2dc0ed46                                                        0.0s
 => => exporting attestation manifest sha256:4cc66e1131e96bf431309fb7031f102d091e4ea85c72f759987b3d358ebd70f2                                          0.0s
 => => exporting manifest list sha256:7f83afdf6c059db37bd8a2673d005685dd59f1a3b94f5a92ffa41962acacf5b8                                                 0.0s
 => => naming to docker.io/newrelic/infrastructure-bundle:dev                                                                                          0.0s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/km3jpktxvdxkn3719kr90ejuv

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview 
SNYK_TOKEN not defined, skipping snyk check
saanamsairajyadav@FDJV7H6TVP infrastructure-bundle % 
``` 

</p>
</details> 