### PR TITLE
Fix: FIPS image tags publishing for pre releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
         go run downloader.go -bundle=bundle-fips.yml -outdir=out-fips
         export DOCKER_PLATFORMS=linux/amd64,linux/arm64
         export OUTDIR=out-fips
-        export BASE_IMAGE_NAME=newrelic/infrastructure-fips
         ./docker-build.sh . --push
         if [[ "${{ github.event.release.prerelease }}" == "false" ]]; then
           export DOCKER_IMAGE_TAG=latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
         go run downloader.go -bundle=bundle-fips.yml -outdir=out-fips
         export DOCKER_PLATFORMS=linux/amd64,linux/arm64
         export OUTDIR=out-fips
+        export BASE_IMAGE_NAME=newrelic/infrastructure-fips
+        export DOCKER_IMAGE=newrelic/infrastructure-bundle-fips
         ./docker-build.sh . --push
         if [[ "${{ github.event.release.prerelease }}" == "false" ]]; then
           export DOCKER_IMAGE_TAG=latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### bugfix
+- Fixed publishing for FIPS pre releases and releases
+
 ## v3.3.1 - 2025-09-18
 
 ### ⛓️ Dependencies


### PR DESCRIPTION
Publishing images for infrastructure bundle fips was broken due the docker image env variable not being passed correctly.
This PR passes that and fixes this issue.

<img width="750" height="736" alt="image" src="https://github.com/user-attachments/assets/a9795950-c074-4cfe-9312-d1c47ca56c3e" />
