### PR TITLE
security: add permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/automated_release.yaml
+++ b/.github/workflows/automated_release.yaml
@@ -7,7 +7,7 @@ on:
 
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   release_management:

--- a/.github/workflows/automated_release.yaml
+++ b/.github/workflows/automated_release.yaml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 10 * * 4"
 
+
+permissions:
+  contents: read
+
 jobs:
   release_management:
     uses: newrelic/coreint-automation/.github/workflows/reusable_release_automation.yaml@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
       - renovate/**
   pull_request:
 
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and scan image

--- a/.github/workflows/infra_bundle_scan_report.yml
+++ b/.github/workflows/infra_bundle_scan_report.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and scan image

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,10 @@ on:
       - master
       - main
 
+
+permissions:
+  contents: read
+
 jobs:
   nightly:
     name: Nightly standard build

--- a/.github/workflows/on-demand.yml
+++ b/.github/workflows/on-demand.yml
@@ -5,6 +5,10 @@ on:
       agent_version:
         description: "Agent version"
         required: true
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and push image

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -3,6 +3,10 @@ on:
   release:
     types: [ prereleased, released ]
 
+
+permissions:
+  contents: read
+
 jobs:
   release-windows-2022:
     name: Release Windows Server 2022

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
   release:
     types: [ prereleased, released ]
 
+
+permissions:
+  contents: read
+
 jobs:
   container-release:
     uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: "14 3 * * *" # Daily at 3:14 AM
 
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and scan image


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to all workflow files missing a permissions block
- Follows the principle of least privilege for GitHub Actions tokens
- Resolves CodeQL alert `actions/missing-workflow-permissions` ([NR-560198](https://new-relic.atlassian.net/browse/NR-560198))

## Test plan
- [ ] Verify CI workflows still pass with the new permissions block
- [ ] Confirm CodeQL alert is resolved after merge

[NR-560198]: https://new-relic.atlassian.net/browse/NR-560198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ