### PR TITLE
ci: strip v prefix from Windows Docker image tags

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -26,6 +26,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: go run downloader.go -bundle="bundle-windows.yml" -outdir="out-windows"
+      - name: Strip v prefix from tag
+        shell: bash
+        run: echo "DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG#v}" >> $GITHUB_ENV
+
       - name: Build Windows Server 2022 image
         env:
           AGENT_VERSION: ${{ steps.agent-version.outputs.version }}
@@ -60,6 +64,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: go run downloader.go -bundle="bundle-windows.yml" -outdir="out-windows"
+      - name: Strip v prefix from tag
+        shell: bash
+        run: echo "DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG#v}" >> $GITHUB_ENV
+
       - name: Build Windows Server 2019 image
         env:
           AGENT_VERSION: ${{ steps.agent-version.outputs.version }}

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: go run downloader.go -bundle="bundle-windows.yml" -outdir="out-windows"
-      - name: Strip v prefix from tag
+      - name: Generate docker image tag from github release tag
         shell: bash
         run: echo "DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG#v}" >> $GITHUB_ENV
 
@@ -64,7 +64,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: go run downloader.go -bundle="bundle-windows.yml" -outdir="out-windows"
-      - name: Strip v prefix from tag
+      - name: Generate docker image tag from github release tag
         shell: bash
         run: echo "DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG#v}" >> $GITHUB_ENV
 


### PR DESCRIPTION
## Problem
Since #680 (Apr 13, 2026) automated the Windows Docker release, all Windows bundle images have been published with a v prefix in the tag — e.g. v3.3.27-ltsc2022 instead of 3.3.27-ltsc2022.

## Root cause: 
github.event.release.tag_name includes the v prefix (e.g. v3.3.27). That value is set as the job-level DOCKER_IMAGE_TAG env var and flows directly into docker-build-windows.sh, which constructs the final image tag as ${DOCKER_IMAGE_TAG}-${WINDOWS_VERSION}.

Linux images were unaffected because they go through the coreint-automation reusable workflow which handles tag normalisation internally.

## Fix
Add a Strip v prefix from tag step in both release jobs (release-windows-2022 and release-windows-2019) immediately before the build step. It uses bash parameter expansion to strip the leading v and writes the result back via $GITHUB_ENV, which overrides the job-level env for all subsequent steps:


## Change local test results:
<img width="1580" height="396" alt="image" src="https://github.com/user-attachments/assets/2358f1e8-21fa-47f3-bf9c-03647d4112dd" />
