### PR TITLE
Refresh inherited OS packages via apk upgrade in bundle image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ ARG TARGETARCH
 ARG jre_version
 ARG out_dir
 
+# Refresh inherited base-image OS packages so transient Alpine CVEs (e.g. curl,
+# libexpat) are patched even when the published base image predates the fix.
+# The base newrelic/infrastructure image runs the same upgrade at build time.
+RUN apk --no-cache upgrade
+
 # required for nri-jmx
 RUN if [ -n "${jre_version}" ]; then apk add --no-cache openjdk8-jre=${jre_version}; else apk add --no-cache openjdk8-jre; fi
 


### PR DESCRIPTION
During the infrastructure-bundle release, we should harden the base image OS packages (curl, libexpat, etc), instead of just adding jre.

**Background:** on [2026-07-04 we released v3.3.33](https://github.com/newrelic/infrastructure-bundle/releases/tag/v3.3.33) based on infrastructure-agent 1.77.1 - which itself was produced on 2026-06-25. Some curl / libcurl / libexpat CVEs had been fixed in between these dates. 
