### PR TITLE
chore: bump agent version to 1.79.0

### DIFF
--- a/bundle-fips.yml
+++ b/bundle-fips.yml
@@ -1,6 +1,6 @@
 # Version of the base agent image to use (`newrelic/infrastructure).
 # This is used by the `docker-build.sh` wrapper if AGENT_VERSION is not set
-agentVersion: 1.78.1
+agentVersion: 1.79.0
 
 # url, stagingUrl, and repo fields are compiled as templates. The `trimv` helper function can be used to remove the leading v
 # from a version string.

--- a/bundle-windows.yml
+++ b/bundle-windows.yml
@@ -1,6 +1,6 @@
 # Version of the base agent image to use (`newrelic/infrastructure`).
 # This is used by the `docker-build-windows.sh` wrapper if AGENT_VERSION is not set
-agentVersion: 1.78.1
+agentVersion: 1.79.0
 
 # url, stagingUrl, and repo fields are compiled as templates. The `trimv` helper function can be used to remove the leading v
 # from a version string.

--- a/bundle.yml
+++ b/bundle.yml
@@ -1,6 +1,6 @@
 # Version of the base agent image to use (`newrelic/infrastructure).
 # This is used by the `docker-build.sh` wrapper if AGENT_VERSION is not set
-agentVersion: 1.78.1
+agentVersion: 1.79.0
 
 # url, stagingUrl, and repo fields are compiled as templates. The `trimv` helper function can be used to remove the leading v
 # from a version string.


### PR DESCRIPTION
Bumps the bundled infrastructure agent version to [1.79.0](https://github.com/newrelic/infrastructure-agent/releases/tag/1.79.0).